### PR TITLE
Pass `pkg.show_progress` down to the subprocess

### DIFF
--- a/R/subprocess.R
+++ b/R/subprocess.R
@@ -38,9 +38,12 @@ remote <- function(func, args = list()) {
         )
         invokeRestart("cli_message_handled")
       },
-      `__body__`
+      {
+        options(pkg.show_progress = `__verbosity__`)
+        `__body__`
+      }
     )},
-    list("__body__" = body(func))
+    list("__body__" = body(func), "__verbosity__" = is_verbose())
   )
 
   res <- withCallingHandlers(


### PR DESCRIPTION
The pak counterpoint to https://github.com/r-lib/pkgdepends/pull/196

An alternative to this is to have pkgdepends respect the `R_PKG_SHOW_PROGRESS` envvar, which we are already setting in the subprocess...