### PR TITLE
Fix version of rprojroot dependency.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Suggests:
     prettyunits,
     processx,
     ps (>= 1.3.0),
-    rprojroot (>= 1.3.2),
+    rprojroot (>= 1.3-2),
     testthat,
     tibble,
     withr,
@@ -68,7 +68,7 @@ Config/pak/dependencies:
     prettyunits,
     processx,
     ps (>= 1.3.0),
-    rprojroot (>= 1.3.2),
+    rprojroot (>= 1.3-2),
     tibble,
     zip
 URL: https://pak.r-lib.org/


### PR DESCRIPTION
There is only 1.3-2, not 1.3.2.

I'm not sure if R treats these the same exactly, but it causes confusion in downstream packaging.