### PR TITLE
distro is now on CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,6 @@ Suggests:
     zip
 Remotes:
     r-lib/pkgdepends,
-    nealrichardson/distro,
     r-lib/ps
 Config/pak/dependencies:
     utils,


### PR DESCRIPTION
https://cran.r-project.org/package=distro

so you don't need Remotes to get it anymore