### PR TITLE
move sudo to outside `execute` of `system_requirements_internal`

### DIFF
--- a/R/system-requirements.R
+++ b/R/system-requirements.R
@@ -116,11 +116,12 @@ system_requirements_internal <- function(os, os_release, root, package, execute,
     callback <- function(x, ...) invisible()
   }
 
+  if (sudo) {
+    cmd <- paste("sudo", cmd)
+  }
+
   if (execute) {
     for (cmd in commands) {
-      if (sudo) {
-        cmd <- paste("sudo", cmd)
-      }
       cli::cli_alert_info("Executing {.code {cmd}}")
 
       processx::run("sh", c("-c", cmd), stdout_callback = callback, stderr_to_stdout = TRUE)


### PR DESCRIPTION
If we just want to print out the command with `sudo` but does not want to execute the command, 
current 'pak' does not prepend "sudo" unless you combine `execute = TRUE`, e.g

```r
pak::pkg_system_requirements("openssl", sudo = TRUE, execute = FALSE)
```
```r
##  [1] "apt-get install -y libssl-dev"
```

This pull request moves `sudo` outside `execute`, so when `sudo = TRUE, execute = FALSE`, the `sudo` will still be prepend to 
output.