### PR TITLE
Fix RStudio's listing in Authors@R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,9 +8,10 @@ Description: The goal of 'pak' is to make package installation faster and
     so it finds version conflicts before performing the installation. This
     version of 'pak' supports CRAN, 'Bioconductor' and 'GitHub' packages as well.
 Authors@R: c(
-    person("Gábor", "Csárdi", email = "csardi.gabor@gmail.com", role = c("aut", "cre")),
-    person("Jim", "Hester", email = "jim.hester@rstudio.com", role = "aut"),
-    person("RStudio", role = "cph", "fnd"))
+    person("Gábor", "Csárdi", , "csardi.gabor@gmail.com", role = c("aut", "cre")),
+    person("Jim", "Hester", , "jim.hester@rstudio.com", role = "aut"),
+    person("RStudio", role = c("cph", "fnd"))
+  )
 License: GPL-3
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
Stumbled across this while doing some analysis needed to make usethis better recognizing RStudio-associated packages.

This PR makes the fix and formats `Authors@R` the way `use_tidy_description()` does.