### PR TITLE
Fix typo in `pkg_install` documentation.

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -168,8 +168,8 @@ NULL
 #'   already installed in another library.
 #' @param upgrade When `FALSE`, the default, does the minimum amount of work
 #'   to give you the latest version of `pkg`. It will only upgrade packages if
-#'   `pkg` or one of its explicitly requires a higher version than what you
-#'   currently have.
+#'   `pkg`, or one of its dependencies, explicitly requires a higher version
+#'   than what you currently have.
 #'
 #'   When `upgrade = TRUE`, will do ensure that you have the latest version of
 #'   `pkg` and all its dependencies.

--- a/man/local_install.Rd
+++ b/man/local_install.Rd
@@ -21,8 +21,8 @@ already installed in another library.}
 
 \item{upgrade}{When \code{FALSE}, the default, does the minimum amount of work
 to give you the latest version of \code{pkg}. It will only upgrade packages if
-\code{pkg} or one of its explicitly requires a higher version than what you
-currently have.
+\code{pkg}, or one of its dependencies, explicitly requires a higher version
+than what you currently have.
 
 When \code{upgrade = TRUE}, will do ensure that you have the latest version of
 \code{pkg} and all its dependencies.}

--- a/man/local_install_deps.Rd
+++ b/man/local_install_deps.Rd
@@ -21,8 +21,8 @@ already installed in another library.}
 
 \item{upgrade}{When \code{FALSE}, the default, does the minimum amount of work
 to give you the latest version of \code{pkg}. It will only upgrade packages if
-\code{pkg} or one of its explicitly requires a higher version than what you
-currently have.
+\code{pkg}, or one of its dependencies, explicitly requires a higher version
+than what you currently have.
 
 When \code{upgrade = TRUE}, will do ensure that you have the latest version of
 \code{pkg} and all its dependencies.}

--- a/man/local_install_dev_deps.Rd
+++ b/man/local_install_dev_deps.Rd
@@ -21,8 +21,8 @@ already installed in another library.}
 
 \item{upgrade}{When \code{FALSE}, the default, does the minimum amount of work
 to give you the latest version of \code{pkg}. It will only upgrade packages if
-\code{pkg} or one of its explicitly requires a higher version than what you
-currently have.
+\code{pkg}, or one of its dependencies, explicitly requires a higher version
+than what you currently have.
 
 When \code{upgrade = TRUE}, will do ensure that you have the latest version of
 \code{pkg} and all its dependencies.}

--- a/man/lockfile_create.Rd
+++ b/man/lockfile_create.Rd
@@ -24,8 +24,8 @@ already installed in another library.}
 
 \item{upgrade}{When \code{FALSE}, the default, does the minimum amount of work
 to give you the latest version of \code{pkg}. It will only upgrade packages if
-\code{pkg} or one of its explicitly requires a higher version than what you
-currently have.
+\code{pkg}, or one of its dependencies, explicitly requires a higher version
+than what you currently have.
 
 When \code{upgrade = TRUE}, will do ensure that you have the latest version of
 \code{pkg} and all its dependencies.}

--- a/man/pkg_install.Rd
+++ b/man/pkg_install.Rd
@@ -22,8 +22,8 @@ already installed in another library.}
 
 \item{upgrade}{When \code{FALSE}, the default, does the minimum amount of work
 to give you the latest version of \code{pkg}. It will only upgrade packages if
-\code{pkg} or one of its explicitly requires a higher version than what you
-currently have.
+\code{pkg}, or one of its dependencies, explicitly requires a higher version
+than what you currently have.
 
 When \code{upgrade = TRUE}, will do ensure that you have the latest version of
 \code{pkg} and all its dependencies.}


### PR DESCRIPTION
Missed word 'dependencies'.