### PR TITLE
Fix syntax error in docs for optional dependency

### DIFF
--- a/man/chunks/FAQ.Rmd
+++ b/man/chunks/FAQ.Rmd
@@ -34,7 +34,7 @@ pak::pkg_install("tibble?source")
 
 ```{asciicast faq-ignore}
 pak::pkg_install(
-  c("tibble", "DiagrammeR=?ignore", "formattable?=ignore"),
+  c("tibble", "DiagrammeR=?ignore", "formattable=?ignore"),
   dependencies = TRUE
 )
 ```


### PR DESCRIPTION
The existing example causes the following warning to be generated in the docs:

```R
#> ! Unknown package parameter: "" in "formattable?=ignore". 
```

I assume this wasn't deliberate since the surrounding text doesn't mention it. I haven't recompiled the documentation since this is just a drive-by edit in the browser.