### PR TITLE
do not overwrite cainfo option

### DIFF
--- a/R/onload.R
+++ b/R/onload.R
@@ -29,7 +29,8 @@ pkg_data <- new.env(parent = emptyenv())
       cli.dynamic = (Sys.getenv("R_PKG_DYNAMIC_TTY") == "TRUE")
     )
     ca_path <- system.file(package = "pak", "curl-ca-bundle.crt")
-    if (ca_path != "") options(async_http_cainfo = ca_path)
+    cainfo <- getOption("async_http_cainfo")
+    if (is.null(cainfo) && ca_path != "") options(async_http_cainfo = ca_path)
     use_private_lib()
 
   } else {


### PR DESCRIPTION
add behaviour to not overwrite option `async_http_cainfo` if set.

Closes #427 