### PR TITLE
Bundle apt-get install commands

### DIFF
--- a/R/system-requirements.R
+++ b/R/system-requirements.R
@@ -131,7 +131,7 @@ system_requirements_internal <- function(os, os_release, root, package, execute,
     install_scripts <- unique(unlist(c(data[["install_scripts"]], lapply(data[["dependencies"]], `[[`, "install_scripts"))))
   }
 
-  commands <- as.character(c(pre_install, install_scripts))
+  commands <- as.character(c(pre_install, simplify_install(install_scripts)))
   if (echo) {
     callback <- function(x, ...) cli::cli_verbatim(sub("[\r\n]+$", "", x))
   } else {
@@ -163,5 +163,19 @@ supported_os_versions <- function() {
     "opensuse" = c("42.3", "15.0"),
     "sle" = c("12.3", "15.0")
     #"windows" = c("")
+  )
+}
+
+# Grouping multiple `apt-get install -y` calls in install scripts.
+# This should be done by the server, but isn't (yet).
+simplify_install <- function(x) {
+  rx <- "^apt-get install -y ([a-z0-9-]+)$"
+  if (length(x) == 0 || !all(grepl(rx, x))) {
+    return(x)
+  }
+
+  paste0(
+    "apt-get install -y ",
+    paste(gsub(rx, "\\1", x), collapse = " ")
   )
 }

--- a/tests/testthat/test-system-requirements.R
+++ b/tests/testthat/test-system-requirements.R
@@ -75,9 +75,7 @@ test_that("local_system_requirements return the system requirements if it has a 
 
   expect_equal(
     local_system_requirements("ubuntu", "16.04", pkg),
-    c("apt-get install -y libcurl4-openssl-dev",
-      "apt-get install -y libssl-dev"
-    )
+    "apt-get install -y libcurl4-openssl-dev libssl-dev"
   )
 
   expect_equal(
@@ -100,9 +98,7 @@ test_that("local_system_requirements return the system requirements if it has a 
 
   expect_equal(
     local_system_requirements("ubuntu", "16.04", pkg),
-    c("apt-get install -y libcurl4-openssl-dev",
-      "apt-get install -y libssl-dev"
-    )
+    "apt-get install -y libcurl4-openssl-dev libssl-dev"
   )
 
   expect_equal(
@@ -126,9 +122,7 @@ test_that("local_system_requirements return the system requirements if 2nd order
 
   expect_equal(
     local_system_requirements("ubuntu", "16.04", pkg),
-    c("apt-get install -y libcurl4-openssl-dev",
-      "apt-get install -y libssl-dev"
-    )
+    "apt-get install -y libcurl4-openssl-dev libssl-dev"
   )
 
   expect_equal(
@@ -144,8 +138,6 @@ test_that("pkg_system_requirements returns the system requirements", {
 
   expect_equal(
     pkg_system_requirements("curl", "ubuntu", "16.04"),
-    c("apt-get install -y libcurl4-openssl-dev",
-      "apt-get install -y libssl-dev"
-    )
+    "apt-get install -y libcurl4-openssl-dev libssl-dev"
   )
 })


### PR DESCRIPTION
Ideally, the server would do this for us. This is a kludge to speed up installation on Ubuntu while we're getting there.

Deliberately not optimizing for other distros yet, because Ubuntu is by far the most common case (GHA install).