### PR TITLE
Typo fix

### DIFF
--- a/R/docs.R
+++ b/R/docs.R
@@ -22,12 +22,12 @@ NULL
 #' ```
 NULL
 
-#' A list of the most imporatant pak features
+#' A list of the most important pak features
 #'
 #' @name Great pak features
 #' @rdname features
 #' @description
-#' A list of the most imporatant pak features.
+#' A list of the most important pak features.
 #'
 #' ```{r child = "man/chunks/features.Rmd"}
 #' ```

--- a/man/features.Rd
+++ b/man/features.Rd
@@ -2,9 +2,9 @@
 % Please edit documentation in R/docs.R
 \name{Great pak features}
 \alias{Great pak features}
-\title{A list of the most imporatant pak features}
+\title{A list of the most important pak features}
 \description{
-A list of the most imporatant pak features.
+A list of the most important pak features.
 }
 \section{pak is fast}{
 \subsection{Parallel HTTP}{


### PR DESCRIPTION
Caught a small typo: `imporatant` -> `important`