### PR TITLE
Add size control in `pkg_search()`

### DIFF
--- a/R/search.R
+++ b/R/search.R
@@ -52,6 +52,7 @@ print.pak_search_result <- function(x, ...) {
   }
 
   md <- attr(x, "metadata")
+  md$size <- min(md$size, md$total - md$from + 1)
   catln(
     "# '", md$query, "' -- hits ", md$from, "-",
     md$from + md$size - 1, " of ", md$total


### PR DESCRIPTION
Fix #505 

This is an attempt to fix the issue.

Let me know how to add tests.

My ad-hoc testing was 

```r
pkg_search("gist")
# 'gist' -- hits 1-4 of 4
pkg_search("git")
# 'git' -- hits 1-10 of 52
pkg_search("git", from = 2)
# 'git' -- hits 2-11 of 52
pkg_search("gist", from = 2)
# 'gist' -- hits 2-4 of 4
pkg_search("git", from = 2, size = 9)
# 'git' -- hits 2-10 of 52
 pkg_search("gist", from = 5)
x No result. :(
 pkg_search("git", from = 50)
# 'git' -- hits 50-52 of 52
```
