### PR TITLE
Tweak documentation for pkg argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 ByteCompile: true
+Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3.9000
 Depends:
     R (>= 3.5)

--- a/R/package.R
+++ b/R/package.R
@@ -5,12 +5,12 @@
 #' package library.
 #'
 #' @param pkg Package names or package references. E.g.
-#'   - `ggplot2`: package from CRAN, Bioconductor or a CRAN-like repository
+#'   - `ggplot2` or `cran::ggplot2`: package from CRAN, Bioconductor or a CRAN-like repository
 #'     in general,
-#'   - `tidyverse/ggplot2`: package from GitHub,
-#'   - `tidyverse/ggplot2@v3.4.0`: package from GitHub tag or branch,
-#'   - `https://examples.com/.../ggplot2_3.3.6.tar.gz`: package from URL,
-#'   - `.`: package in the current working directory.
+#'   - `tidyverse/ggplot2` or `github::tidyverse/ggplot2`: package from GitHub,
+#'   - `tidyverse/ggplot2@v3.4.0` or `github::tidyverse/ggplot2@v3.4.0`: package from GitHub tag or branch,
+#'   - `url::https://examples.com/.../ggplot2_3.3.6.tar.gz`: package from URL,
+#'   - `.` or `local::.`: package in the current working directory.
 #'
 #'   See "[Package sources]" for more details.
 #' @param lib Package library to install the packages to. Note that _all_

--- a/man/cache.Rd
+++ b/man/cache.Rd
@@ -53,78 +53,19 @@ packages in the package cache.
 \section{Examples}{
 
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{cache_summary()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> $cachepath                                                              
-#> [1] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/pkg"  
-#>                                                                         
-#> $files                                                                  
-#> [1] 483                                                                 
-#>                                                                         
-#> $size                                                                   
-#> [1] 654662486                                                           
-#>                                                                         
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{cache_summary()
+}\if{html}{\out{</div>}}
 
 
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{cache_list()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 483 × 11</span>                                                
-#>    fullpath       path  package url   etag  sha256 version platf…¹ built
-#>    <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>          <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;int&gt;</span>
-#> <span style="color: #c2c2c2;"> 1</span> /Users/gaborc… arch… <span style="color: #DC322F;">NA</span>      http… <span style="color: #999999;">"</span>\\"1… 0c8f0… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>         <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 2</span> /Users/gaborc… bin/… evalua… http… <span style="color: #999999;">"</span>\\"1… 08a39… 0.17    aarch6…    <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 3</span> /Users/gaborc… bin/… crayon  http… <span style="color: #999999;">"</span>\\"2… 1e6d5… 1.5.2   aarch6…    <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 4</span> /Users/gaborc… bin/… common… http… <span style="color: #999999;">"</span>\\"4… 47b4a… 1.8.1   aarch6…    <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 5</span> /Users/gaborc… bin/… curl    http… <span style="color: #999999;">"</span>\\"b… 7b8ba… 4.3.3   aarch6…    <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 6</span> /Users/gaborc… bin/… tinytex http… <span style="color: #999999;">"</span>\\"2… 7e9ba… 0.42    aarch6…    <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 7</span> /Users/gaborc… bin/… jsonli… http… <span style="color: #999999;">"</span>\\"1… 68e59… 1.8.2   aarch6…    <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 8</span> /Users/gaborc… bin/… lifecy… http… <span style="color: #999999;">"</span>\\"1… 7ce27… 1.0.3   aarch6…    <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 9</span> /Users/gaborc… bin/… vctrs   http… <span style="color: #999999;">"</span>\\"1… c3a69… 0.4.2   aarch6…    <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;">10</span> /Users/gaborc… src/… pkgcac… <span style="color: #DC322F;">NA</span>     <span style="color: #DC322F;">NA</span>   9b70a… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>          0
-#> <span style="color: #999999;"># … with 473 more rows, 2 more variables: vignettes &lt;int&gt;,</span>              
-#> <span style="color: #999999;">#   rversion &lt;chr&gt;, and abbreviated variable name ¹​platform</span>            
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{cache_list()
+}\if{html}{\out{</div>}}
 
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{cache_list(package = "recipes")
+}\if{html}{\out{</div>}}
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{cache_list(package = "recipes")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 1 × 11</span>                                                  
-#>   fullp…¹ path  package url   etag  sha256 version platf…² built vigne…³
-#>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;int&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;int&gt;</span>
-#> <span style="color: #c2c2c2;">1</span> /Users… bin/… recipes http… <span style="color: #999999;">"</span>\\"1… e281e… 1.0.2   aarch6…    <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>
-#> <span style="color: #999999;"># … with 1 more variable: rversion &lt;chr&gt;, and abbreviated variable</span>      
-#> <span style="color: #999999;">#   names ¹​fullpath, ²​platform, ³​vignettes</span>                           
-</pre></div>
-}}
-
-
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{cache_list(platform = "source")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 69 × 11</span>                                                 
-#>    fullpath       path  package url   etag  sha256 version platf…¹ built
-#>    <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>          <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;int&gt;</span>
-#> <span style="color: #c2c2c2;"> 1</span> /Users/gaborc… src/… crayon  http… <span style="color: #999999;">"</span>\\"9… 70a9a… 1.5.2   source     <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 2</span> /Users/gaborc… src/… zip     http… <span style="color: #999999;">"</span>\\"1… 14873… 2.2.1   source     <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 3</span> /Users/gaborc… src/… curl    http… <span style="color: #999999;">"</span>\\"a… 3567b… 4.3.3   source     <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 4</span> /Users/gaborc… src/… rlang   http… <span style="color: #999999;">"</span>\\"b… e6973… 1.0.6   source     <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 5</span> /Users/gaborc… src/… openssl http… <span style="color: #999999;">"</span>\\"1… 7cde9… 2.0.3   source     <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 6</span> /Users/gaborc… src/… tinytex http… <span style="color: #999999;">"</span>\\"8… 205f7… 0.42    source     <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 7</span> /Users/gaborc… src/… evalua… http… <span style="color: #999999;">"</span>\\"6… 49c74… 0.17    source     <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 8</span> /Users/gaborc… src/… Rcpp    http… <span style="color: #999999;">"</span>\\"2… 807ce… 1.0.9   source     <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 9</span> /Users/gaborc… src/… knitr   http… <span style="color: #999999;">"</span>\\"d… 9b8f9… 1.40    source     <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;">10</span> /Users/gaborc… src/… lpSolve http… <span style="color: #999999;">"</span>\\"7… f7258… 5.6.17  source     <span style="color: #DC322F;">NA</span>
-#> <span style="color: #999999;"># … with 59 more rows, 2 more variables: vignettes &lt;int&gt;,</span>               
-#> <span style="color: #999999;">#   rversion &lt;chr&gt;, and abbreviated variable name ¹​platform</span>            
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{cache_list(platform = "source")
+}\if{html}{\out{</div>}}
 
 
 

--- a/man/faq.Rd
+++ b/man/faq.Rd
@@ -14,58 +14,11 @@ Sometimes you still want a reinstall, e.g. to fix a broken installation.
 In this case you can delete the package and then install it, or use the
 \code{?reinstall} parameter:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::pkg_install("tibble")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                                                         
-#> → Will <span style="font-style: italic;">install</span> 13 packages.                                             
-#> → All 13 packages (7.68 MB) are cached.                                 
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">cli</span>         3.3.0                                                     
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">crayon</span>      1.5.1                                                     
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">ellipsis</span>    0.3.2                                                     
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">fansi</span>       1.0.3                                                     
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">glue</span>        1.6.2                                                     
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">lifecycle</span>   1.0.1                                                     
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">magrittr</span>    2.0.3                                                     
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">pillar</span>      1.7.0                                                     
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">pkgconfig</span>   2.0.3                                                     
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">rlang</span>       1.0.2                                                     
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">tibble</span>      3.1.7                                                     
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">utf8</span>        1.2.2                                                     
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">vctrs</span>       0.4.1                                                     
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed, 13 pkgs (7.68 MB) are cached                 
-#> <span style="color: #859900;">✔</span> Got <span style="color: #268BD2;">utf8</span> 1.2.2 (aarch64-apple-darwin20) (209.24 kB)                   
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">cli</span> 3.3.0  <span style="color: #a3a3a3;">(76ms)</span>                                           
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">crayon</span> 1.5.1  <span style="color: #a3a3a3;">(87ms)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">ellipsis</span> 0.3.2  <span style="color: #a3a3a3;">(97ms)</span>                                      
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">fansi</span> 1.0.3  <span style="color: #a3a3a3;">(103ms)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">glue</span> 1.6.2  <span style="color: #a3a3a3;">(111ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">lifecycle</span> 1.0.1  <span style="color: #a3a3a3;">(153ms)</span>                                    
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">magrittr</span> 2.0.3  <span style="color: #a3a3a3;">(158ms)</span>                                     
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">pillar</span> 1.7.0  <span style="color: #a3a3a3;">(162ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">pkgconfig</span> 2.0.3  <span style="color: #a3a3a3;">(87ms)</span>                                     
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">rlang</span> 1.0.2  <span style="color: #a3a3a3;">(39ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">tibble</span> 3.1.7  <span style="color: #a3a3a3;">(41ms)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">utf8</span> 1.2.2  <span style="color: #a3a3a3;">(39ms)</span>                                          
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">vctrs</span> 0.4.1  <span style="color: #a3a3a3;">(32ms)</span>                                         
-#> <span style="color: #859900;">✔</span> 1 pkg + 12 deps: added 13, dld 1 (209.24 kB) <span style="color: #b8b8b8;">[1.8s]</span>                   
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::pkg_install("tibble")
+}\if{html}{\out{</div>}}
 
-
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::pkg_install("tibble?reinstall")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                                                         
-#> → Will <span style="font-style: italic;">install</span> 1 package.                                               
-#> → The package (724.32 kB) is cached.                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">tibble</span>   3.1.7                                                        
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed, 1 pkg (724.32 kB) is cached                  
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">tibble</span> 3.1.7  <span style="color: #a3a3a3;">(42ms)</span>                                        
-#> <span style="color: #859900;">✔</span> 1 pkg + 12 deps: kept 11, added 1 <span style="color: #b8b8b8;">[343ms]</span>                             
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::pkg_install("tibble?reinstall")
+}\if{html}{\out{</div>}}
 }
 
 \subsection{How do I install a dependency from a binary package}{
@@ -87,21 +40,8 @@ with \code{pkg = NULL}, so for these you need to explicitly use \code{upgrade = 
 To force the installation of a source package (instead of a binary
 package), use the \code{?source} parameter:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::pkg_install("tibble?source")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                                                         
-#> → Will <span style="font-style: italic;">install</span> 1 package.                                               
-#> → The package (672.34 kB) is cached.                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">tibble</span>   3.1.7 👷🏼‍♀️🔧                                                 
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed, 1 pkg (672.34 kB) is cached                  
-#> <span style="color: #2AA198;">ℹ</span> Building <span style="color: #268BD2;">tibble</span> 3.1.7                                                 
-#> <span style="color: #859900;">✔</span> Built <span style="color: #268BD2;">tibble</span> 3.1.7 <span style="color: #a3a3a3;">(3.1s)</span>                                             
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">tibble</span> 3.1.7  <span style="color: #a3a3a3;">(35ms)</span>                                        
-#> <span style="color: #859900;">✔</span> 1 pkg + 12 deps: kept 11, added 1 <span style="color: #b8b8b8;">[4.1s]</span>                              
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::pkg_install("tibble?source")
+}\if{html}{\out{</div>}}
 }
 
 \subsection{How do I install the latest version of a dependency?}{
@@ -112,37 +52,17 @@ parameter with the \verb{<package>=} form: \verb{<package>=?source}.
 For example to install tibble, with its cli dependency installed from
 source you could write:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::pkg_install(c("tibble", "cli=?source"))
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                                                         
-#> → Will <span style="font-style: italic;">install</span> 1 package.                                               
-#> → The package (540.04 kB) is cached.                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">cli</span>   3.3.0 👷🏽🔧                                                       
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed, 1 pkg (540.04 kB) is cached                  
-#> <span style="color: #2AA198;">ℹ</span> Building <span style="color: #268BD2;">cli</span> 3.3.0                                                    
-#> <span style="color: #859900;">✔</span> Built <span style="color: #268BD2;">cli</span> 3.3.0 <span style="color: #a3a3a3;">(4.5s)</span>                                                
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">cli</span> 3.3.0  <span style="color: #a3a3a3;">(68ms)</span>                                           
-#> <span style="color: #859900;">✔</span> 1 pkg + 12 deps: kept 11, added 1 <span style="color: #b8b8b8;">[4.9s]</span>                              
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::pkg_install(c("tibble", "cli=?source"))
+}\if{html}{\out{</div>}}
 }
 
 \subsection{How do I ignore an optional dependency?}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::pkg_install(
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::pkg_install(
   c("tibble", "DiagrammeR=?ignore", "formattable=?ignore"),
   dependencies = TRUE
 )
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                                                         
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed                                               
-#> <span style="color: #859900;">✔</span> 1 pkg + 12 deps: kept 12 <span style="color: #b8b8b8;">[583ms]</span>                                      
-</pre></div>
-}}
-
+}\if{html}{\out{</div>}}
 
 The syntax is
 

--- a/man/get-started.Rd
+++ b/man/get-started.Rd
@@ -10,10 +10,8 @@ This manual page collects the most common pak use cases.
 \section{Package installation}{
 \subsection{Install a package from CRAN or Bioconductor}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::pkg_install("tibble")
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::pkg_install("tibble")
 }\if{html}{\out{</div>}}
-
-\if{html}{\figure{tldr-cran.svg}}
 
 pak automatically sets a CRAN repository and the Bioconductor repositories
 that correspons to the current R version.
@@ -21,29 +19,8 @@ that correspons to the current R version.
 
 \subsection{Install a package from GitHub}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::pkg_install("tidyverse/tibble")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                                                         
-#> → Will <span style="font-style: italic;">update</span> 2 packages.                                               
-#> → All 2 packages (0 B) are cached.                                      
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">tibble</span> 3.1.8 → 3.1.8<span style="font-weight: bold;">.9002</span> 👷🏻🔧 (GitHub: 37ec86a)                       
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">vctrs</span>  0.5.1 → 0.5.1<span style="font-weight: bold;">.9000</span> 👷🏾‍♀️🔧 (GitHub: 2d7de76)                    
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed, 2 pkgs are cached                            
-#> <span style="color: #2AA198;">ℹ</span> Packaging <span style="color: #268BD2;">vctrs</span> 0.5.1.9000                                            
-#> <span style="color: #859900;">✔</span> Packaged <span style="color: #268BD2;">vctrs</span> 0.5.1.9000 <span style="color: #a3a3a3;">(1.4s)</span>                                      
-#> <span style="color: #2AA198;">ℹ</span> Building <span style="color: #268BD2;">vctrs</span> 0.5.1.9000                                             
-#> <span style="color: #859900;">✔</span> Built <span style="color: #268BD2;">vctrs</span> 0.5.1.9000 <span style="color: #a3a3a3;">(11.2s)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">vctrs</span> 0.5.1.9000 (github::r-lib/vctrs@2d7de76) <span style="color: #a3a3a3;">(34ms)</span>       
-#> <span style="color: #2AA198;">ℹ</span> Packaging <span style="color: #268BD2;">tibble</span> 3.1.8.9002                                           
-#> <span style="color: #859900;">✔</span> Packaged <span style="color: #268BD2;">tibble</span> 3.1.8.9002 <span style="color: #a3a3a3;">(502ms)</span>                                    
-#> <span style="color: #2AA198;">ℹ</span> Building <span style="color: #268BD2;">tibble</span> 3.1.8.9002                                            
-#> <span style="color: #859900;">✔</span> Built <span style="color: #268BD2;">tibble</span> 3.1.8.9002 <span style="color: #a3a3a3;">(2.7s)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">tibble</span> 3.1.8.9002 (github::tidyverse/tibble@37ec86a) <span style="color: #a3a3a3;">(28ms)</span> 
-#> <span style="color: #859900;">✔</span> 1 pkg + 10 deps: kept 9, upd 2 <span style="color: #b8b8b8;">[17.5s]</span>                                
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::pkg_install("tidyverse/tibble")
+}\if{html}{\out{</div>}}
 
 Use the \code{user/repo} form.
 You can specify a branch or tag: \code{user/repo@branch} or \code{user/repo@tag}.
@@ -51,26 +28,10 @@ You can specify a branch or tag: \code{user/repo@branch} or \code{user/repo@tag}
 
 \subsection{Install a package from a URL}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::pkg_install(
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::pkg_install(
   "url::https://cran.r-project.org/src/contrib/Archive/tibble/tibble_3.1.7.tar.gz"
 )
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                                                         
-#> → Will <span style="font-style: italic;">install</span> 1 package.                                               
-#> → Will <span style="font-style: italic;">update</span> 1 package.                                                
-#> → All 2 packages (38.65 kB) are cached.                                 
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">ellipsis</span>              0.3.2                                           
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">tibble</span>   3.1.8.9002 → 3.1.<span style="font-weight: bold;">7</span> 👷🏻‍♀️🔧                                    
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed, 2 pkgs (38.65 kB) are cached                 
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">ellipsis</span> 0.3.2  <span style="color: #a3a3a3;">(18ms)</span>                                      
-#> <span style="color: #2AA198;">ℹ</span> Building <span style="color: #268BD2;">tibble</span> 3.1.7                                                 
-#> <span style="color: #859900;">✔</span> Built <span style="color: #268BD2;">tibble</span> 3.1.7 <span style="color: #a3a3a3;">(2.5s)</span>                                             
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">tibble</span> 3.1.7  <span style="color: #a3a3a3;">(31ms)</span>                                        
-#> <span style="color: #859900;">✔</span> 1 pkg + 11 deps: kept 10, upd 1, added 1 <span style="color: #b8b8b8;">[3.3s]</span>                       
-</pre></div>
-}}
-
+}\if{html}{\out{</div>}}
 
 The URL may point to an R package file, made with \verb{R CMD build}, or a
 \code{.tar.gz} or \code{.zip} archive of a package tree.
@@ -80,34 +41,16 @@ The URL may point to an R package file, made with \verb{R CMD build}, or a
 \section{Package updates}{
 \subsection{Update a package}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::pkg_install("tibble")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                                                         
-#> → Will <span style="font-style: italic;">update</span> 1 package.                                                
-#> → The package (724.32 kB) is cached.                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">tibble</span> 3.1.7 → 3.1.<span style="font-weight: bold;">8</span>                                                  
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed, 1 pkg (724.32 kB) is cached                  
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">tibble</span> 3.1.8  <span style="color: #a3a3a3;">(36ms)</span>                                        
-#> <span style="color: #859900;">✔</span> 1 pkg + 10 deps: kept 10, upd 1 <span style="color: #b8b8b8;">[368ms]</span>                               
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::pkg_install("tibble")
+}\if{html}{\out{</div>}}
 
 \code{pak::pkg_install()} automatically updates the package.
 }
 
 \subsection{Update all dependencies of a package}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::pkg_install("tibble", upgrade = TRUE)
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                                                         
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed                                               
-#> <span style="color: #859900;">✔</span> 1 pkg + 10 deps: kept 11 <span style="color: #b8b8b8;">[278ms]</span>                                      
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::pkg_install("tibble", upgrade = TRUE)
+}\if{html}{\out{</div>}}
 
 \code{upgrade = TRUE} updates the package itself and all of its dependencies, if
 necessary.
@@ -117,124 +60,32 @@ necessary.
 
 Add \code{?reinstall} to the package name or package reference in general:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::pkg_install("tibble?reinstall")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                                                         
-#> → Will <span style="font-style: italic;">install</span> 1 package.                                               
-#> → The package (724.32 kB) is cached.                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">tibble</span>   3.1.8                                                        
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed, 1 pkg (724.32 kB) is cached                  
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">tibble</span> 3.1.8  <span style="color: #a3a3a3;">(60ms)</span>                                        
-#> <span style="color: #859900;">✔</span> 1 pkg + 10 deps: kept 10, added 1 <span style="color: #b8b8b8;">[340ms]</span>                             
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::pkg_install("tibble?reinstall")
+}\if{html}{\out{</div>}}
 }
 }
 
 \section{Dependency lookup}{
 \subsection{Dependencies of a CRAN or Bioconductor package}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::pkg_deps("tibble")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 11 × 32</span>                                                 
-#>    ref       type  direct direc…¹ status package version license needs…²
-#>    <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>     <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;lgl&gt;</span>  <span style="font-style: italic;color: #999999;">&lt;lgl&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;lgl&gt;</span>  
-#> <span style="color: #c2c2c2;"> 1</span> cli       stan… FALSE  FALSE   OK     cli     3.4.1   MIT + … FALSE  
-#> <span style="color: #c2c2c2;"> 2</span> fansi     stan… FALSE  FALSE   OK     fansi   1.0.3   GPL-2 … FALSE  
-#> <span style="color: #c2c2c2;"> 3</span> glue      stan… FALSE  FALSE   OK     glue    1.6.2   MIT + … FALSE  
-#> <span style="color: #c2c2c2;"> 4</span> lifecycle stan… FALSE  FALSE   OK     lifecy… 1.0.3   MIT + … FALSE  
-#> <span style="color: #c2c2c2;"> 5</span> magrittr  stan… FALSE  FALSE   OK     magrit… 2.0.3   MIT + … FALSE  
-#> <span style="color: #c2c2c2;"> 6</span> pillar    stan… FALSE  FALSE   OK     pillar  1.8.1   MIT + … FALSE  
-#> <span style="color: #c2c2c2;"> 7</span> pkgconfig stan… FALSE  FALSE   OK     pkgcon… 2.0.3   MIT + … FALSE  
-#> <span style="color: #c2c2c2;"> 8</span> rlang     stan… FALSE  FALSE   OK     rlang   1.0.6   MIT + … FALSE  
-#> <span style="color: #c2c2c2;"> 9</span> tibble    stan… TRUE   TRUE    OK     tibble  3.1.8   MIT + … FALSE  
-#> <span style="color: #c2c2c2;">10</span> utf8      stan… FALSE  FALSE   OK     utf8    1.2.2   Apache… FALSE  
-#> <span style="color: #c2c2c2;">11</span> vctrs     stan… FALSE  FALSE   OK     vctrs   0.5.1   MIT + … FALSE  
-#> <span style="color: #999999;"># … with 23 more variables: priority &lt;chr&gt;, md5sum &lt;chr&gt;, sha256 &lt;chr&gt;,</span> 
-#> <span style="color: #999999;">#   filesize &lt;int&gt;, built &lt;chr&gt;, platform &lt;chr&gt;, rversion &lt;chr&gt;,</span>        
-#> <span style="color: #999999;">#   repotype &lt;chr&gt;, repodir &lt;chr&gt;, target &lt;chr&gt;, deps &lt;list&gt;,</span>           
-#> <span style="color: #999999;">#   mirror &lt;chr&gt;, sources &lt;list&gt;, remote &lt;list&gt;, error &lt;list&gt;,</span>          
-#> <span style="color: #999999;">#   metadata &lt;list&gt;, dep_types &lt;list&gt;, params &lt;list&gt;, sysreqs &lt;chr&gt;,</span>    
-#> <span style="color: #999999;">#   cache_status &lt;chr&gt;, lib_status &lt;chr&gt;, old_version &lt;chr&gt;,</span>            
-#> <span style="color: #999999;">#   new_version &lt;chr&gt;, and abbreviated variable names ¹​directpkg, …</span>    
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::pkg_deps("tibble")
+}\if{html}{\out{</div>}}
 
 The results are returned in a data frame.
 }
 
 \subsection{Dependency tree of a CRAN / Bioconductor package}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::pkg_deps_tree("tibble")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="font-weight: bold;font-style: italic;color: #2AA198;">tibble </span><span style="font-weight: bold;font-style: italic;color: #525252;">3.1.8</span> <span style="color: #859900;">✨</span>                                                          
-#> ├─fansi <span style="color: #525252;">1.0.3</span> <span style="color: #859900;">✨</span>                                                         
-#> ├─lifecycle <span style="color: #525252;">1.0.3</span> <span style="color: #859900;">✨</span>                                                     
-#> │ ├─cli <span style="color: #525252;">3.4.1</span> <span style="color: #859900;">✨</span>                                                         
-#> │ ├─glue <span style="color: #525252;">1.6.2</span> <span style="color: #859900;">✨</span>                                                        
-#> │ └─rlang <span style="color: #525252;">1.0.6</span> <span style="color: #859900;">✨</span>                                                       
-#> ├─magrittr <span style="color: #525252;">2.0.3</span> <span style="color: #859900;">✨</span>                                                      
-#> ├─pillar <span style="color: #525252;">1.8.1</span> <span style="color: #859900;">✨</span>                                                        
-#> │ ├─cli                                                                 
-#> │ ├─fansi                                                               
-#> │ ├─glue                                                                
-#> │ ├─lifecycle                                                           
-#> │ ├─rlang                                                               
-#> │ ├─utf8 <span style="color: #525252;">1.2.2</span> <span style="color: #859900;">✨</span>                                                        
-#> │ └─vctrs <span style="color: #525252;">0.5.1</span> <span style="color: #859900;">✨</span>                                                       
-#> │   ├─cli                                                               
-#> │   ├─glue                                                              
-#> │   ├─lifecycle                                                         
-#> │   └─rlang                                                             
-#> ├─pkgconfig <span style="color: #525252;">2.0.3</span> <span style="color: #859900;">✨</span>                                                     
-#> ├─rlang                                                                 
-#> └─vctrs                                                                 
-#>                                                                         
-#> Key:  <span style="color: #859900;">✨</span> new                                                             
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::pkg_deps_tree("tibble")
+}\if{html}{\out{</div>}}
 
 The results are also silently returned in a data frame.
 }
 
 \subsection{Dependency tree of a package on GitHub}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::pkg_deps_tree("tidyverse/tibble")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="font-weight: bold;font-style: italic;color: #2AA198;">tidyverse/tibble </span><span style="font-weight: bold;font-style: italic;color: #525252;">3.1.8.9002</span> <span style="color: #859900;">✨👷🏼🔧 </span>                                       
-#> ├─fansi <span style="color: #525252;">1.0.3</span> <span style="color: #859900;">✨</span>                                                         
-#> ├─lifecycle <span style="color: #525252;">1.0.3</span> <span style="color: #859900;">✨</span>                                                     
-#> │ ├─cli <span style="color: #525252;">3.4.1</span> <span style="color: #859900;">✨</span>                                                         
-#> │ ├─glue <span style="color: #525252;">1.6.2</span> <span style="color: #859900;">✨</span>                                                        
-#> │ └─rlang <span style="color: #525252;">1.0.6</span> <span style="color: #859900;">✨</span>                                                       
-#> ├─magrittr <span style="color: #525252;">2.0.3</span> <span style="color: #859900;">✨</span>                                                      
-#> ├─pillar <span style="color: #525252;">1.8.1</span> <span style="color: #859900;">✨</span>                                                        
-#> │ ├─cli                                                                 
-#> │ ├─fansi                                                               
-#> │ ├─glue                                                                
-#> │ ├─lifecycle                                                           
-#> │ ├─rlang                                                               
-#> │ ├─utf8 <span style="color: #525252;">1.2.2</span> <span style="color: #859900;">✨</span>                                                        
-#> │ └─r-lib/vctrs <span style="color: #525252;">0.5.1.9000</span> <span style="color: #859900;">✨👷🏼🔧 </span>                                        
-#> │   ├─cli                                                               
-#> │   ├─glue                                                              
-#> │   ├─lifecycle                                                         
-#> │   └─rlang                                                             
-#> ├─pkgconfig <span style="color: #525252;">2.0.3</span> <span style="color: #859900;">✨</span>                                                     
-#> ├─rlang                                                                 
-#> └─r-lib/vctrs                                                           
-#>                                                                         
-#> Key:  <span style="color: #859900;">✨</span> new | <span style="color: #859900;">👷🏼 </span>build | 🔧<span style="color: #859900;"> </span>compile                                      
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::pkg_deps_tree("tidyverse/tibble")
+}\if{html}{\out{</div>}}
 
 Use the \code{user/repo} form.
 As usual, you can also select a branch, tag, or sha, with the
@@ -243,36 +94,8 @@ As usual, you can also select a branch, tag, or sha, with the
 
 \subsection{Dependency tree of the package in the current directory}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::local_deps_tree("tibble")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="font-weight: bold;font-style: italic;color: #2AA198;">local::tibble </span><span style="font-weight: bold;font-style: italic;color: #525252;">3.1.8</span> <span style="color: #859900;">✨👷🏻‍♀️🔧    </span>                                         
-#> ├─fansi <span style="color: #525252;">1.0.3</span> <span style="color: #859900;">✨</span>                                                         
-#> ├─lifecycle <span style="color: #525252;">1.0.3</span> <span style="color: #859900;">✨</span>                                                     
-#> │ ├─cli <span style="color: #525252;">3.4.1</span> <span style="color: #859900;">✨</span>                                                         
-#> │ ├─glue <span style="color: #525252;">1.6.2</span> <span style="color: #859900;">✨</span>                                                        
-#> │ └─rlang <span style="color: #525252;">1.0.6</span> <span style="color: #859900;">✨</span>                                                       
-#> ├─magrittr <span style="color: #525252;">2.0.3</span> <span style="color: #859900;">✨</span>                                                      
-#> ├─pillar <span style="color: #525252;">1.8.1</span> <span style="color: #859900;">✨</span>                                                        
-#> │ ├─cli                                                                 
-#> │ ├─fansi                                                               
-#> │ ├─glue                                                                
-#> │ ├─lifecycle                                                           
-#> │ ├─rlang                                                               
-#> │ ├─utf8 <span style="color: #525252;">1.2.2</span> <span style="color: #859900;">✨</span>                                                        
-#> │ └─vctrs <span style="color: #525252;">0.5.1</span> <span style="color: #859900;">✨</span>                                                       
-#> │   ├─cli                                                               
-#> │   ├─glue                                                              
-#> │   ├─lifecycle                                                         
-#> │   └─rlang                                                             
-#> ├─pkgconfig <span style="color: #525252;">2.0.3</span> <span style="color: #859900;">✨</span>                                                     
-#> ├─rlang                                                                 
-#> └─vctrs                                                                 
-#>                                                                         
-#> Key:  <span style="color: #859900;">✨</span> new | <span style="color: #859900;">👷🏻‍♀️ bui</span>ld | 🔧 co<span style="color: #859900;">m</span>pile                                   
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::local_deps_tree("tibble")
+}\if{html}{\out{</div>}}
 
 Assuming package is in directory \code{tibble}.
 }
@@ -281,20 +104,8 @@ Assuming package is in directory \code{tibble}.
 
 How does tibble depend on rlang?
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::pkg_deps_explain("tibble", "rlang")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> tibble -&gt; lifecycle -&gt; rlang                                            
-#> tibble -&gt; pillar -&gt; lifecycle -&gt; rlang                                  
-#> tibble -&gt; pillar -&gt; rlang                                               
-#> tibble -&gt; pillar -&gt; vctrs -&gt; lifecycle -&gt; rlang                         
-#> tibble -&gt; pillar -&gt; vctrs -&gt; rlang                                      
-#> tibble -&gt; rlang                                                         
-#> tibble -&gt; vctrs -&gt; lifecycle -&gt; rlang                                   
-#> tibble -&gt; vctrs -&gt; rlang                                                
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::pkg_deps_explain("tibble", "rlang")
+}\if{html}{\out{</div>}}
 
 Use can also use the \code{user/repo} form for packages from GitHub,
 \code{url::...} for packages at URLs, etc.
@@ -304,243 +115,20 @@ Use can also use the \code{user/repo} form for packages from GitHub,
 \section{Package development}{
 \subsection{Install dependencies of local package}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::local_install_deps()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #859900;">✔</span> Loading metadata database ... done                                    
-#>                                                                         
-#> → The package (0 B) is cached.                                          
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed                                               
-#> <span style="color: #859900;">✔</span> 10 deps: kept 10 <span style="color: #b8b8b8;">[3.2s]</span>                                               
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::local_install_deps()
+}\if{html}{\out{</div>}}
 }
 
 \subsection{Install local package}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::local_install()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                                                         
-#> → Will <span style="font-style: italic;">update</span> 1 package.                                                
-#> → The package (0 B) is cached.                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">tibble</span> 3.1.8 → 3.1.8 👷🏻‍♂️🔧                                           
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed, 1 pkg is cached                              
-#> <span style="color: #859900;">✔</span> Got <span style="color: #268BD2;">tibble</span> 3.1.8 (source) (96 B)                                      
-#> <span style="color: #2AA198;">ℹ</span> Packaging <span style="color: #268BD2;">tibble</span> 3.1.8                                                
-#> <span style="color: #859900;">✔</span> Packaged <span style="color: #268BD2;">tibble</span> 3.1.8 <span style="color: #a3a3a3;">(864ms)</span>                                         
-#> <span style="color: #2AA198;">ℹ</span> Building <span style="color: #268BD2;">tibble</span> 3.1.8                                                 
-#> <span style="color: #859900;">✔</span> Built <span style="color: #268BD2;">tibble</span> 3.1.8 <span style="color: #a3a3a3;">(2.4s)</span>                                             
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">tibble</span> 3.1.8 (local) <span style="color: #a3a3a3;">(38ms)</span>                                 
-#> <span style="color: #859900;">✔</span> 1 pkg + 10 deps: kept 10, upd 1, dld 1 (NA B) <span style="color: #b8b8b8;">[4.2s]</span>                  
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::local_install()
+}\if{html}{\out{</div>}}
 }
 
 \subsection{Install all dependencies of local package}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::local_install_dev_deps()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                                                         
-#> → Will <span style="font-style: italic;">install</span> 86 packages.                                             
-#> → Will <span style="font-style: italic;">update</span> 2 packages.                                               
-#> → All 89 packages (100.53 MB) are cached.                               
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">askpass</span>                1.1                                            
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">base64enc</span>              0.1-3                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">bench</span>                  1.1.2                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">bit</span>                    4.0.5                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">bit64</span>                  4.0.5                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">blob</span>                   1.2.3                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">brio</span>                   1.1.3                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">bslib</span>                  0.4.1                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">cachem</span>                 1.0.6                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">callr</span>                  3.7.3                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">clipr</span>                  0.8.0                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">colorspace</span>             2.0-3                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">covr</span>                   3.6.1                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">crayon</span>                 1.5.2                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">curl</span>                   4.3.3                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">desc</span>                   1.4.2                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">DiagrammeR</span>             1.0.9                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">diffobj</span>                0.3.5                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">digest</span>                 0.6.31                                         
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">downloader</span>             0.4                                            
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">dplyr</span>                  1.0.10                                         
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">evaluate</span>               0.19    👷🏿‍♂️                                  
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">farver</span>                 2.1.1                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">fastmap</span>                1.1.0                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">formattable</span>            0.2.1                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">fs</span>                     1.5.2                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">generics</span>               0.1.3                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">ggplot2</span>                3.4.0                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">gridExtra</span>              2.3                                            
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">gtable</span>                 0.3.1                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">highr</span>                  0.9                                            
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">hms</span>                    1.1.2                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">htmltools</span>              0.5.4                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">htmlwidgets</span>            1.6.0   👷🏾‍♂️                                  
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">httr</span>                   1.4.4                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">igraph</span>                 1.3.5                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">influenceR</span>             0.1.0.1                                        
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">isoband</span>                0.2.6                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">jquerylib</span>              0.1.4                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">jsonlite</span>               1.8.4                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">knitr</span>                  1.41                                           
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">labeling</span>               0.4.2                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">lazyeval</span>               0.2.2                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">lubridate</span>              1.9.0                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">Matrix</span>       1.5-1   → 1.5-<span style="font-weight: bold;">3</span>                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">memoise</span>                2.0.1                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">mime</span>                   0.12                                           
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">mockr</span>                  0.2.0                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">munsell</span>                0.5.0                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">nlme</span>         3.1-160 → 3.1-<span style="font-weight: bold;">161</span> 👷‍♂️🔧                                  
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">nycflights13</span>           1.0.2                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">openssl</span>                2.0.5                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">pkgbuild</span>               1.4.0                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">pkgload</span>                1.3.2                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">praise</span>                 1.0.0                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">prettyunits</span>            1.1.1                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">processx</span>               3.8.0                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">profmem</span>                0.6.0                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">ps</span>                     1.7.2                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">purrr</span>                  0.3.5                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">R6</span>                     2.5.1                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">rappdirs</span>               0.3.3                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">RColorBrewer</span>           1.1-3                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">readr</span>                  2.1.3                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">rematch2</span>               2.1.2                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">rex</span>                    1.2.1                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">rmarkdown</span>              2.19    👷‍♂️                                   
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">rprojroot</span>              2.0.3                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">rstudioapi</span>             0.14                                           
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">sass</span>                   0.4.4                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">scales</span>                 1.2.1                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">stringi</span>                1.7.8                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">stringr</span>                1.5.0                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">sys</span>                    3.4.1                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">testthat</span>               3.1.6                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">tidyr</span>                  1.2.1                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">tidyselect</span>             1.2.0                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">timechange</span>             0.1.1                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">tinytex</span>                0.43    👷🏻‍♂️                                  
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">tzdb</span>                   0.3.0                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">viridis</span>                0.6.2                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">viridisLite</span>            0.4.1                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">visNetwork</span>             2.1.2                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">vroom</span>                  1.6.0                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">waldo</span>                  0.4.0                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">withr</span>                  2.5.0                                          
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">xfun</span>                   0.35                                           
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">yaml</span>                   2.3.6                                          
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed, 88 pkgs (100.53 MB) are cached               
-#> <span style="color: #2AA198;">ℹ</span> Packaging <span style="color: #268BD2;">tibble</span> 3.1.8                                                
-#> <span style="color: #2AA198;">ℹ</span> Building <span style="color: #268BD2;">evaluate</span> 0.19                                                
-#> <span style="color: #2AA198;">ℹ</span> Building <span style="color: #268BD2;">nlme</span> 3.1-161                                                 
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">R6</span> 2.5.1  <span style="color: #a3a3a3;">(31ms)</span>                                            
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">DiagrammeR</span> 1.0.9  <span style="color: #a3a3a3;">(76ms)</span>                                    
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">RColorBrewer</span> 1.1-3  <span style="color: #a3a3a3;">(72ms)</span>                                  
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">askpass</span> 1.1  <span style="color: #a3a3a3;">(79ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">Matrix</span> 1.5-3  <span style="color: #a3a3a3;">(137ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">base64enc</span> 0.1-3  <span style="color: #a3a3a3;">(125ms)</span>                                    
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">bench</span> 1.1.2  <span style="color: #a3a3a3;">(90ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">bit64</span> 4.0.5  <span style="color: #a3a3a3;">(44ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">bit</span> 4.0.5  <span style="color: #a3a3a3;">(43ms)</span>                                           
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">blob</span> 1.2.3  <span style="color: #a3a3a3;">(41ms)</span>                                          
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">brio</span> 1.1.3  <span style="color: #a3a3a3;">(40ms)</span>                                          
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">cachem</span> 1.0.6  <span style="color: #a3a3a3;">(31ms)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">callr</span> 3.7.3  <span style="color: #a3a3a3;">(53ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">clipr</span> 0.8.0  <span style="color: #a3a3a3;">(89ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">colorspace</span> 2.0-3  <span style="color: #a3a3a3;">(99ms)</span>                                    
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">covr</span> 3.6.1  <span style="color: #a3a3a3;">(58ms)</span>                                          
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">crayon</span> 1.5.2  <span style="color: #a3a3a3;">(75ms)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">curl</span> 4.3.3  <span style="color: #a3a3a3;">(83ms)</span>                                          
-#> <span style="color: #859900;">✔</span> Packaged <span style="color: #268BD2;">tibble</span> 3.1.8 <span style="color: #a3a3a3;">(684ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">bslib</span> 0.4.1  <span style="color: #a3a3a3;">(315ms)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">desc</span> 1.4.2  <span style="color: #a3a3a3;">(77ms)</span>                                          
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">diffobj</span> 0.3.5  <span style="color: #a3a3a3;">(68ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">digest</span> 0.6.31  <span style="color: #a3a3a3;">(60ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">downloader</span> 0.4  <span style="color: #a3a3a3;">(39ms)</span>                                      
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">dplyr</span> 1.0.10  <span style="color: #a3a3a3;">(39ms)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">farver</span> 2.1.1  <span style="color: #a3a3a3;">(41ms)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">fastmap</span> 1.1.0  <span style="color: #a3a3a3;">(38ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">formattable</span> 0.2.1  <span style="color: #a3a3a3;">(43ms)</span>                                   
-#> <span style="color: #859900;">✔</span> Built <span style="color: #268BD2;">evaluate</span> 0.19 <span style="color: #a3a3a3;">(903ms)</span>                                           
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">fs</span> 1.5.2  <span style="color: #a3a3a3;">(49ms)</span>                                            
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">generics</span> 0.1.3  <span style="color: #a3a3a3;">(46ms)</span>                                      
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">ggplot2</span> 3.4.0  <span style="color: #a3a3a3;">(65ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">gridExtra</span> 2.3  <span style="color: #a3a3a3;">(43ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">gtable</span> 0.3.1  <span style="color: #a3a3a3;">(38ms)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">highr</span> 0.9  <span style="color: #a3a3a3;">(37ms)</span>                                           
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">hms</span> 1.1.2  <span style="color: #a3a3a3;">(39ms)</span>                                           
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">htmltools</span> 0.5.4  <span style="color: #a3a3a3;">(40ms)</span>                                     
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">httr</span> 1.4.4  <span style="color: #a3a3a3;">(40ms)</span>                                          
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">influenceR</span> 0.1.0.1  <span style="color: #a3a3a3;">(17ms)</span>                                  
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">igraph</span> 1.3.5  <span style="color: #a3a3a3;">(96ms)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">isoband</span> 0.2.6  <span style="color: #a3a3a3;">(68ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">jquerylib</span> 0.1.4  <span style="color: #a3a3a3;">(38ms)</span>                                     
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">jsonlite</span> 1.8.4  <span style="color: #a3a3a3;">(37ms)</span>                                      
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">labeling</span> 0.4.2  <span style="color: #a3a3a3;">(14ms)</span>                                      
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">knitr</span> 1.41  <span style="color: #a3a3a3;">(73ms)</span>                                          
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">lazyeval</span> 0.2.2  <span style="color: #a3a3a3;">(43ms)</span>                                      
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">lubridate</span> 1.9.0  <span style="color: #a3a3a3;">(38ms)</span>                                     
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">memoise</span> 2.0.1  <span style="color: #a3a3a3;">(39ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">mime</span> 0.12  <span style="color: #a3a3a3;">(58ms)</span>                                           
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">mockr</span> 0.2.0  <span style="color: #a3a3a3;">(38ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">munsell</span> 0.5.0  <span style="color: #a3a3a3;">(36ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">nycflights13</span> 1.0.2  <span style="color: #a3a3a3;">(37ms)</span>                                  
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">openssl</span> 2.0.5  <span style="color: #a3a3a3;">(41ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">pkgbuild</span> 1.4.0  <span style="color: #a3a3a3;">(39ms)</span>                                      
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">pkgload</span> 1.3.2  <span style="color: #a3a3a3;">(37ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">praise</span> 1.0.0  <span style="color: #a3a3a3;">(35ms)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">prettyunits</span> 1.1.1  <span style="color: #a3a3a3;">(56ms)</span>                                   
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">processx</span> 3.8.0  <span style="color: #a3a3a3;">(37ms)</span>                                      
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">profmem</span> 0.6.0  <span style="color: #a3a3a3;">(37ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">ps</span> 1.7.2  <span style="color: #a3a3a3;">(37ms)</span>                                            
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">purrr</span> 0.3.5  <span style="color: #a3a3a3;">(38ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">rappdirs</span> 0.3.3  <span style="color: #a3a3a3;">(37ms)</span>                                      
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">readr</span> 2.1.3  <span style="color: #a3a3a3;">(42ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">rematch2</span> 2.1.2  <span style="color: #a3a3a3;">(41ms)</span>                                      
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">rex</span> 1.2.1  <span style="color: #a3a3a3;">(58ms)</span>                                           
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">rprojroot</span> 2.0.3  <span style="color: #a3a3a3;">(58ms)</span>                                     
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">rstudioapi</span> 0.14  <span style="color: #a3a3a3;">(40ms)</span>                                     
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">sass</span> 0.4.4  <span style="color: #a3a3a3;">(42ms)</span>                                          
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">scales</span> 1.2.1  <span style="color: #a3a3a3;">(39ms)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">stringr</span> 1.5.0  <span style="color: #a3a3a3;">(33ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">sys</span> 3.4.1  <span style="color: #a3a3a3;">(49ms)</span>                                           
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">testthat</span> 3.1.6  <span style="color: #a3a3a3;">(88ms)</span>                                      
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">tidyr</span> 1.2.1  <span style="color: #a3a3a3;">(77ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">stringi</span> 1.7.8  <span style="color: #a3a3a3;">(195ms)</span>                                      
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">tidyselect</span> 1.2.0  <span style="color: #a3a3a3;">(113ms)</span>                                   
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">timechange</span> 0.1.1  <span style="color: #a3a3a3;">(55ms)</span>                                    
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">tzdb</span> 0.3.0  <span style="color: #a3a3a3;">(40ms)</span>                                          
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">viridisLite</span> 0.4.1  <span style="color: #a3a3a3;">(39ms)</span>                                   
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">viridis</span> 0.6.2  <span style="color: #a3a3a3;">(39ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">visNetwork</span> 2.1.2  <span style="color: #a3a3a3;">(77ms)</span>                                    
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">vroom</span> 1.6.0  <span style="color: #a3a3a3;">(77ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">waldo</span> 0.4.0  <span style="color: #a3a3a3;">(62ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">withr</span> 2.5.0  <span style="color: #a3a3a3;">(40ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">xfun</span> 0.35  <span style="color: #a3a3a3;">(39ms)</span>                                           
-#> <span style="color: #2AA198;">ℹ</span> Building <span style="color: #268BD2;">tinytex</span> 0.43                                                 
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">yaml</span> 2.3.6  <span style="color: #a3a3a3;">(43ms)</span>                                          
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">evaluate</span> 0.19  <span style="color: #a3a3a3;">(15ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Built <span style="color: #268BD2;">tinytex</span> 0.43 <span style="color: #a3a3a3;">(1.1s)</span>                                             
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">tinytex</span> 0.43  <span style="color: #a3a3a3;">(15ms)</span>                                        
-#> <span style="color: #2AA198;">ℹ</span> Building <span style="color: #268BD2;">rmarkdown</span> 2.19                                               
-#> <span style="color: #859900;">✔</span> Built <span style="color: #268BD2;">rmarkdown</span> 2.19 <span style="color: #a3a3a3;">(3.9s)</span>                                           
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">rmarkdown</span> 2.19  <span style="color: #a3a3a3;">(85ms)</span>                                      
-#> <span style="color: #2AA198;">ℹ</span> Building <span style="color: #268BD2;">htmlwidgets</span> 1.6.0                                            
-#> <span style="color: #859900;">✔</span> Built <span style="color: #268BD2;">nlme</span> 3.1-161 <span style="color: #a3a3a3;">(8s)</span>                                               
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">nlme</span> 3.1-161  <span style="color: #a3a3a3;">(33ms)</span>                                        
-#> <span style="color: #859900;">✔</span> Built <span style="color: #268BD2;">htmlwidgets</span> 1.6.0 <span style="color: #a3a3a3;">(1.1s)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">htmlwidgets</span> 1.6.0  <span style="color: #a3a3a3;">(22ms)</span>                                   
-#> <span style="color: #859900;">✔</span> 103 deps: kept 15, upd 2, added 86 <span style="color: #b8b8b8;">[10.2s]</span>                            
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::local_install_dev_deps()
+}\if{html}{\out{</div>}}
 
 Installs development and optional dependencies as well.
 }
@@ -549,21 +137,8 @@ Installs development and optional dependencies as well.
 \section{Repositories}{
 \subsection{List current repositories}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::repo_get()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 5 × 5</span>                                                   
-#>   name          url                                type  r_ver…¹ bioc_…²
-#> <span style="color: #c2c2c2;">*</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>         <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>                              <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  
-#> <span style="color: #c2c2c2;">1</span> CRAN          https://cloud.r-project.org        cran  *       <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;">2</span> BioCsoft      https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">3</span> BioCann       https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">4</span> BioCexp       https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">5</span> BioCworkflows https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #999999;"># … with abbreviated variable names ¹​r_version, ²​bioc_version</span>         
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::repo_get()
+}\if{html}{\out{</div>}}
 
 If you haven't set a CRAN or Bioconductor repository, pak does that
 automatically.
@@ -571,43 +146,16 @@ automatically.
 
 \subsection{Add custom repository}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::repo_add(rhub = 'https://r-hub.r-universe.dev')
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::repo_add(rhub = 'https://r-hub.r-universe.dev')
 pak::repo_get()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 6 × 5</span>                                                   
-#>   name          url                                type  r_ver…¹ bioc_…²
-#> <span style="color: #c2c2c2;">*</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>         <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>                              <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  
-#> <span style="color: #c2c2c2;">1</span> CRAN          https://cloud.r-project.org        cran  *       <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;">2</span> rhub          https://r-hub.r-universe.dev       cran… *       <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;">3</span> BioCsoft      https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">4</span> BioCann       https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">5</span> BioCexp       https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">6</span> BioCworkflows https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #999999;"># … with abbreviated variable names ¹​r_version, ²​bioc_version</span>         
-</pre></div>
-}}
-
+}\if{html}{\out{</div>}}
 }
 
 \subsection{Remove custom repositories}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{options(repos = getOption("repos")["CRAN"])
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{options(repos = getOption("repos")["CRAN"])
 pak::repo_get()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 5 × 5</span>                                                   
-#>   name          url                                type  r_ver…¹ bioc_…²
-#> <span style="color: #c2c2c2;">*</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>         <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>                              <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  
-#> <span style="color: #c2c2c2;">1</span> CRAN          https://cloud.r-project.org        cran  *       <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;">2</span> BioCsoft      https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">3</span> BioCann       https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">4</span> BioCexp       https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">5</span> BioCworkflows https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #999999;"># … with abbreviated variable names ¹​r_version, ²​bioc_version</span>         
-</pre></div>
-}}
-
+}\if{html}{\out{</div>}}
 
 If you set the \code{repos} option to a CRAN repo only, or unset it completely,
 then pak keeps only CRAN and (by default) Bioconductor.
@@ -615,22 +163,9 @@ then pak keeps only CRAN and (by default) Bioconductor.
 
 \subsection{Time travel using RSPM}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::repo_add(CRAN = "RSPM@2022-06-30")
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::repo_add(CRAN = "RSPM@2022-06-30")
 pak::repo_get()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 5 × 5</span>                                                   
-#>   name          url                                type  r_ver…¹ bioc_…²
-#> <span style="color: #c2c2c2;">*</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>         <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>                              <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  
-#> <span style="color: #c2c2c2;">1</span> CRAN          https://packagemanager.posit.co/c… cran  *       <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;">2</span> BioCsoft      https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">3</span> BioCann       https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">4</span> BioCexp       https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">5</span> BioCworkflows https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #999999;"># … with abbreviated variable names ¹​r_version, ²​bioc_version</span>         
-</pre></div>
-}}
-
+}\if{html}{\out{</div>}}
 
 Sets a repository that is equivalent to CRAN's state closest to the
 specified date.
@@ -640,22 +175,9 @@ repository.
 
 \subsection{Time travel using MRAN}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::repo_add(CRAN = "MRAN@2022-06-30")
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::repo_add(CRAN = "MRAN@2022-06-30")
 pak::repo_get()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 5 × 5</span>                                                   
-#>   name          url                                type  r_ver…¹ bioc_…²
-#> <span style="color: #c2c2c2;">*</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>         <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>                              <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  
-#> <span style="color: #c2c2c2;">1</span> CRAN          https://cran.microsoft.com/snapsh… cran  *       <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;">2</span> BioCsoft      https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">3</span> BioCann       https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">4</span> BioCexp       https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">5</span> BioCworkflows https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #999999;"># … with abbreviated variable names ¹​r_version, ²​bioc_version</span>         
-</pre></div>
-}}
-
+}\if{html}{\out{</div>}}
 
 Sets a repository that is equivalent to CRAN's state at the specified date.
 Name this repository \code{CRAN}, otherwise pak will also add a default CRAN
@@ -667,34 +189,8 @@ repository.
 By default pak caches both metadata and downloaded packages.
 \subsection{Inspect metadata cache}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::meta_list()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #859900;">✔</span> Updated metadata database: 4.55 MB in 4 files.                        
-#> <span style="color: #859900;">✔</span> Updating metadata database ... done                                   
-#> <span style="color: #999999;"># A data frame: 43,718 × 32</span>                                             
-#>    package version depends sugge…¹ license imports linki…² archs enhan…³
-#>    <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  
-#> <span style="color: #c2c2c2;"> 1</span> A3      1.0.0   R (&gt;= … random… GPL (&gt;… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 2</span> AATtoo… 0.0.1   R (&gt;= … <span style="color: #DC322F;">NA</span>      GPL-3   magrit… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 3</span> ABACUS  1.0.0   R (&gt;= … rmarkd… GPL-3   ggplot… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 4</span> ABC.RAP 0.9.0   R (&gt;= … knitr,… GPL-3   graphi… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 5</span> ABCana… 1.2.1   R (&gt;= … <span style="color: #DC322F;">NA</span>      GPL-3   plotrix <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 6</span> ABCopt… 0.15.0  <span style="color: #DC322F;">NA</span>      testth… MIT + … Rcpp, … Rcpp    ABCo… <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 7</span> ABCp2   1.2     MASS    <span style="color: #DC322F;">NA</span>      GPL-2   <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 8</span> ABHgen… 1.0.1   <span style="color: #DC322F;">NA</span>      knitr,… GPL-3   ggplot… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 9</span> ABPS    0.3     <span style="color: #DC322F;">NA</span>      testth… GPL (&gt;… kernlab <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;">10</span> ACA     1.1     R (&gt;= … <span style="color: #DC322F;">NA</span>      GPL     graphi… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #999999;"># … with 43,708 more rows, 23 more variables: os_type &lt;chr&gt;,</span>            
-#> <span style="color: #999999;">#   priority &lt;chr&gt;, license_is_foss &lt;chr&gt;, license_restricts_use &lt;chr&gt;,</span> 
-#> <span style="color: #999999;">#   repodir &lt;chr&gt;, rversion &lt;chr&gt;, platform &lt;chr&gt;,</span>                      
-#> <span style="color: #999999;">#   needscompilation &lt;chr&gt;, ref &lt;chr&gt;, type &lt;chr&gt;, direct &lt;lgl&gt;,</span>        
-#> <span style="color: #999999;">#   status &lt;chr&gt;, target &lt;chr&gt;, mirror &lt;chr&gt;, sources &lt;list&gt;,</span>           
-#> <span style="color: #999999;">#   filesize &lt;int&gt;, sha256 &lt;chr&gt;, sysreqs &lt;chr&gt;, built &lt;chr&gt;,</span>           
-#> <span style="color: #999999;">#   published &lt;dttm&gt;, deps &lt;list&gt;, md5sum &lt;chr&gt;, path &lt;chr&gt;, and …</span>      
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::meta_list()
+}\if{html}{\out{</div>}}
 }
 
 \subsection{Update metadata cache}{
@@ -703,86 +199,29 @@ By default \code{pkg_install()} and similar functions automatically update the
 metadata for the currently set repositories if it is older than 24 hours.
 You can also force an update manually:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::meta_update()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #859900;">✔</span> Updating metadata database ... done                                   
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::meta_update()
+}\if{html}{\out{</div>}}
 }
 
 \subsection{Clean metadata cache}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::meta_clean(force = TRUE)
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::meta_clean(force = TRUE)
 pak::meta_summary()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> [1] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/_metad
-#> ata"                                                                    
-#>                                                                         
-#> $current_db                                                             
-#> [1] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/_metad
-#> ata/pkgs-d1c324e625.rds"                                                
-#>                                                                         
-#> $raw_files                                                              
-#> character(0)                                                            
-#>                                                                         
-#> $db_files                                                               
-#> character(0)                                                            
-#>                                                                         
-#> $size                                                                   
-#> [1] 0                                                                   
-#>                                                                         
-</pre></div>
-}}
-
+}\if{html}{\out{</div>}}
 }
 
 \subsection{Inspect package cache}{
 
 Downloaded packages are also cached.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::cache_list()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 480 × 11</span>                                                
-#>    fullpath       path  package url   etag  sha256 version platf…¹ built
-#>    <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>          <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;int&gt;</span>
-#> <span style="color: #c2c2c2;"> 1</span> /Users/gaborc… arch… <span style="color: #DC322F;">NA</span>      http… <span style="color: #999999;">"</span>\\"1… 0c8f0… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>         <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 2</span> /Users/gaborc… bin/… evalua… http… <span style="color: #999999;">"</span>\\"1… 08a39… 0.17    aarch6…    <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 3</span> /Users/gaborc… bin/… crayon  http… <span style="color: #999999;">"</span>\\"2… 1e6d5… 1.5.2   aarch6…    <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 4</span> /Users/gaborc… bin/… common… http… <span style="color: #999999;">"</span>\\"4… 47b4a… 1.8.1   aarch6…    <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 5</span> /Users/gaborc… bin/… curl    http… <span style="color: #999999;">"</span>\\"b… 7b8ba… 4.3.3   aarch6…    <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 6</span> /Users/gaborc… bin/… tinytex http… <span style="color: #999999;">"</span>\\"2… 7e9ba… 0.42    aarch6…    <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 7</span> /Users/gaborc… bin/… jsonli… http… <span style="color: #999999;">"</span>\\"1… 68e59… 1.8.2   aarch6…    <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 8</span> /Users/gaborc… bin/… lifecy… http… <span style="color: #999999;">"</span>\\"1… 7ce27… 1.0.3   aarch6…    <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;"> 9</span> /Users/gaborc… bin/… vctrs   http… <span style="color: #999999;">"</span>\\"1… c3a69… 0.4.2   aarch6…    <span style="color: #DC322F;">NA</span>
-#> <span style="color: #c2c2c2;">10</span> /Users/gaborc… src/… pkgcac… <span style="color: #DC322F;">NA</span>     <span style="color: #DC322F;">NA</span>   9b70a… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>          0
-#> <span style="color: #999999;"># … with 470 more rows, 2 more variables: vignettes &lt;int&gt;,</span>              
-#> <span style="color: #999999;">#   rversion &lt;chr&gt;, and abbreviated variable name ¹​platform</span>            
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::cache_list()
+}\if{html}{\out{</div>}}
 }
 
 \subsection{View a package cache summary}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::cache_summary()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> $cachepath                                                              
-#> [1] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/pkg"  
-#>                                                                         
-#> $files                                                                  
-#> [1] 480                                                                 
-#>                                                                         
-#> $size                                                                   
-#> [1] 653325143                                                           
-#>                                                                         
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::cache_summary()
+}\if{html}{\out{</div>}}
 }
 
 \subsection{Clean package cache}{
@@ -795,32 +234,8 @@ Downloaded packages are also cached.
 \section{Libraries}{
 \subsection{List packages in a library}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak::lib_status(Sys.getenv("R_LIBS_USER"))
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 701 × 39</span>                                                
-#>    library   package title version depends repos…¹ license needs…² built
-#>    <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>     <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;lgl&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>
-#> <span style="color: #c2c2c2;"> 1</span> /Users/g… abc     <span style="color: #999999;">"</span>Too… 2.2.1   R (&gt;= … CRAN    GPL (&gt;… FALSE   R 4.…
-#> <span style="color: #c2c2c2;"> 2</span> /Users/g… abc.da… <span style="color: #999999;">"</span>Dat… 1.0     R (&gt;= … CRAN    GPL (&gt;… FALSE   R 4.…
-#> <span style="color: #c2c2c2;"> 3</span> /Users/g… abind   <span style="color: #999999;">"</span>Com… 1.4-5   R (&gt;= … CRAN    LGPL (… FALSE   R 4.…
-#> <span style="color: #c2c2c2;"> 4</span> /Users/g… ade4    <span style="color: #999999;">"</span>Ana… 1.7-19  R (&gt;= … CRAN    GPL (&gt;… TRUE    R 4.…
-#> <span style="color: #c2c2c2;"> 5</span> /Users/g… ape     <span style="color: #999999;">"</span>Ana… 5.6-2   R (&gt;= … CRAN    GPL-2 … TRUE    R 4.…
-#> <span style="color: #c2c2c2;"> 6</span> /Users/g… aplot   <span style="color: #999999;">"</span>Dec… 0.1.7   <span style="color: #DC322F;">NA</span>      CRAN    Artist… FALSE   R 4.…
-#> <span style="color: #c2c2c2;"> 7</span> /Users/g… archive <span style="color: #999999;">"</span>Mul… 1.1.5   R (&gt;= … CRAN    MIT + … TRUE    R 4.…
-#> <span style="color: #c2c2c2;"> 8</span> /Users/g… arrayh… <span style="color: #999999;">"</span>Con… 1.1-0   <span style="color: #DC322F;">NA</span>      CRAN    GPL     FALSE   R 4.…
-#> <span style="color: #c2c2c2;"> 9</span> /Users/g… arrow   <span style="color: #999999;">"</span>Int… 9.0.0   R (&gt;= … CRAN    Apache… TRUE    R 4.…
-#> <span style="color: #c2c2c2;">10</span> /Users/g… arules  <span style="color: #999999;">"</span>Min… 1.7-5   R (&gt;= … CRAN    GPL-3   TRUE    R 4.…
-#> <span style="color: #999999;"># … with 691 more rows, 30 more variables: remotetype &lt;chr&gt;,</span>            
-#> <span style="color: #999999;">#   remotepkgref &lt;chr&gt;, remoteref &lt;chr&gt;, remoterepos &lt;chr&gt;,</span>             
-#> <span style="color: #999999;">#   remotepkgplatform &lt;chr&gt;, remotesha &lt;chr&gt;, imports &lt;chr&gt;,</span>            
-#> <span style="color: #999999;">#   suggests &lt;chr&gt;, linkingto &lt;chr&gt;, remotes &lt;chr&gt;, remotehost &lt;chr&gt;,</span>   
-#> <span style="color: #999999;">#   remoterepo &lt;chr&gt;, remoteusername &lt;chr&gt;, enhances &lt;chr&gt;,</span>             
-#> <span style="color: #999999;">#   biocviews &lt;chr&gt;, remoteurl &lt;chr&gt;, remotesubdir &lt;chr&gt;,</span>               
-#> <span style="color: #999999;">#   priority &lt;chr&gt;, remoteetag &lt;chr&gt;, remotepackaged &lt;chr&gt;, …</span>           
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak::lib_status(Sys.getenv("R_LIBS_USER"))
+}\if{html}{\out{</div>}}
 
 Pass the directory of the library as the argument.
 }

--- a/man/lib_status.Rd
+++ b/man/lib_status.Rd
@@ -23,31 +23,8 @@ Status of packages in a library
 \section{Examples}{
 
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{lib_status(.Library)
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 31 × 31</span>                                                 
-#>    library   package version prior…¹ title license sugge…² built depends
-#>    <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>     <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  
-#> <span style="color: #c2c2c2;"> 1</span> /Library… base    4.2.2   base    <span style="color: #999999;">"</span>The… Part o… methods R 4.… <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 2</span> /Library… boot    1.3-28  recomm… <span style="color: #999999;">"</span>Boo… Unlimi… MASS, … R 4.… R (&gt;= …
-#> <span style="color: #c2c2c2;"> 3</span> /Library… class   7.3-20  recomm… <span style="color: #999999;">"</span>Fun… GPL-2 … <span style="color: #DC322F;">NA</span>      R 4.… R (&gt;= …
-#> <span style="color: #c2c2c2;"> 4</span> /Library… cluster 2.1.4   recomm… <span style="color: #999999;">"</span>\\"F… GPL (&gt;… MASS, … R 4.… R (&gt;= …
-#> <span style="color: #c2c2c2;"> 5</span> /Library… codeto… 0.2-18  recomm… <span style="color: #999999;">"</span>Cod… GPL     <span style="color: #DC322F;">NA</span>      R 4.… R (&gt;= …
-#> <span style="color: #c2c2c2;"> 6</span> /Library… compil… 4.2.2   base    <span style="color: #999999;">"</span>The… Part o… <span style="color: #DC322F;">NA</span>      R 4.… <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 7</span> /Library… datase… 4.2.2   base    <span style="color: #999999;">"</span>The… Part o… <span style="color: #DC322F;">NA</span>      R 4.… <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 8</span> /Library… filelo… 1.0.2   <span style="color: #DC322F;">NA</span>      <span style="color: #999999;">"</span>Por… MIT + … callr … R 4.… <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 9</span> /Library… foreign 0.8-83  recomm… <span style="color: #999999;">"</span>Rea… GPL (&gt;… <span style="color: #DC322F;">NA</span>      R 4.… R (&gt;= …
-#> <span style="color: #c2c2c2;">10</span> /Library… graphi… 4.2.2   base    <span style="color: #999999;">"</span>The… Part o… <span style="color: #DC322F;">NA</span>      R 4.… <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #999999;"># … with 21 more rows, 22 more variables: needscompilation &lt;lgl&gt;,</span>       
-#> <span style="color: #999999;">#   repository &lt;chr&gt;, imports &lt;chr&gt;, remotetype &lt;chr&gt;,</span>                  
-#> <span style="color: #999999;">#   remotepkgref &lt;chr&gt;, remoteref &lt;chr&gt;, remoterepos &lt;chr&gt;,</span>             
-#> <span style="color: #999999;">#   remotepkgplatform &lt;chr&gt;, remotesha &lt;chr&gt;, enhances &lt;chr&gt;,</span>           
-#> <span style="color: #999999;">#   linkingto &lt;chr&gt;, md5sum &lt;chr&gt;, platform &lt;chr&gt;, biocviews &lt;chr&gt;,</span>     
-#> <span style="color: #999999;">#   sysreqs &lt;chr&gt;, ref &lt;chr&gt;, type &lt;chr&gt;, status &lt;chr&gt;, rversion &lt;chr&gt;,</span> 
-#> <span style="color: #999999;">#   sources &lt;list&gt;, repotype &lt;chr&gt;, deps &lt;list&gt;, and abbreviated …</span>      
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{lib_status(.Library)
+}\if{html}{\out{</div>}}
 }
 
 \seealso{

--- a/man/lockfile_create.Rd
+++ b/man/lockfile_create.Rd
@@ -15,12 +15,12 @@ lockfile_create(
 \arguments{
 \item{pkg}{Package names or package references. E.g.
 \itemize{
-\item \code{ggplot2}: package from CRAN, Bioconductor or a CRAN-like repository
+\item \code{ggplot2} or \code{cran::ggplot2}: package from CRAN, Bioconductor or a CRAN-like repository
 in general,
-\item \code{tidyverse/ggplot2}: package from GitHub,
-\item \code{tidyverse/ggplot2@v3.4.0}: package from GitHub tag or branch,
-\item \verb{https://examples.com/.../ggplot2_3.3.6.tar.gz}: package from URL,
-\item \code{.}: package in the current working directory.
+\item \code{tidyverse/ggplot2} or \code{github::tidyverse/ggplot2}: package from GitHub,
+\item \code{tidyverse/ggplot2@v3.4.0} or \code{github::tidyverse/ggplot2@v3.4.0}: package from GitHub tag or branch,
+\item \verb{url::https://examples.com/.../ggplot2_3.3.6.tar.gz}: package from URL,
+\item \code{.} or \code{local::.}: package in the current working directory.
 }
 
 See "\link{Package sources}" for more details.}

--- a/man/metadata.Rd
+++ b/man/metadata.Rd
@@ -62,104 +62,48 @@ Metadata cache summary:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{meta_summary()
 #> $cachepath
-#> [1] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/_metadata"
+#> [1] "/home/runner/.cache/R/pkgcache/_metadata"
 #> 
 #> $current_db
-#> [1] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/_metadata/pkgs-34444e3072.rds"
+#> [1] "/home/runner/.cache/R/pkgcache/_metadata/pkgs-c22cd3b850.rds"
 #> 
 #> $raw_files
-#>  [1] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/_metadata/BioCann-59693086a0/bin/macosx/big-sur-arm64/contrib/4.2/PACKAGES.gz"      
-#>  [2] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/_metadata/BioCann-59693086a0/src/contrib/PACKAGES.gz"                               
-#>  [3] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/_metadata/BioCexp-90d4a3978b/bin/macosx/big-sur-arm64/contrib/4.2/PACKAGES.gz"      
-#>  [4] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/_metadata/BioCexp-90d4a3978b/src/contrib/PACKAGES.gz"                               
-#>  [5] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/_metadata/BioCsoft-2a43920999/bin/macosx/big-sur-arm64/contrib/4.2/PACKAGES.gz"     
-#>  [6] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/_metadata/BioCsoft-2a43920999/src/contrib/PACKAGES.gz"                              
-#>  [7] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/_metadata/BioCworkflows-26330ba3ca/bin/macosx/big-sur-arm64/contrib/4.2/PACKAGES.gz"
-#>  [8] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/_metadata/BioCworkflows-26330ba3ca/src/contrib/PACKAGES.gz"                         
-#>  [9] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/_metadata/CRAN-075c426938/bin/macosx/big-sur-arm64/contrib/4.2/PACKAGES.gz"         
-#> [10] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/_metadata/CRAN-075c426938/src/contrib/PACKAGES.gz"                                  
+#> [1] "/home/runner/.cache/R/pkgcache/_metadata/BioCann-133378caf4/src/contrib/PACKAGES.gz"      
+#> [2] "/home/runner/.cache/R/pkgcache/_metadata/BioCbooks-acae71babc/src/contrib/PACKAGES.gz"    
+#> [3] "/home/runner/.cache/R/pkgcache/_metadata/BioCexp-9d0a1dae1d/src/contrib/PACKAGES.gz"      
+#> [4] "/home/runner/.cache/R/pkgcache/_metadata/BioCsoft-41b228b7fc/src/contrib/PACKAGES.gz"     
+#> [5] "/home/runner/.cache/R/pkgcache/_metadata/BioCworkflows-6b25871327/src/contrib/PACKAGES.gz"
+#> [6] "/home/runner/.cache/R/pkgcache/_metadata/CRAN-075c426938/src/contrib/PACKAGES.gz"         
+#> [7] "/home/runner/.cache/R/pkgcache/_metadata/RSPM-49260a4dff/src/contrib/PACKAGES.gz"         
 #> 
 #> $db_files
-#> [1] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/_metadata/pkgs-34444e3072.rds"
-#> [2] "/Users/gaborcsardi/Library/Caches/org.R-project.R/R/pkgcache/_metadata/pkgs-ccacf1b389.rds"
+#> [1] "/home/runner/.cache/R/pkgcache/_metadata/pkgs-c22cd3b850.rds"
 #> 
 #> $size
-#> [1] 174848200
+#> [1] 111564643
 }\if{html}{\out{</div>}}
 
 
 The current metadata DB:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{meta_list()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #859900;">✔</span> Loading metadata database ... done                                    
-#> <span style="color: #999999;"># A data frame: 45,279 × 32</span>                                             
-#>    package version depends sugge…¹ license imports linki…² archs enhan…³
-#>    <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  
-#> <span style="color: #c2c2c2;"> 1</span> A3      1.0.0   R (&gt;= … random… GPL (&gt;… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 2</span> AATtoo… 0.0.2   R (&gt;= … <span style="color: #DC322F;">NA</span>      GPL-3   magrit… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 3</span> ABACUS  1.0.0   R (&gt;= … rmarkd… GPL-3   ggplot… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 4</span> ABC.RAP 0.9.0   R (&gt;= … knitr,… GPL-3   graphi… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 5</span> ABCana… 1.2.1   R (&gt;= … <span style="color: #DC322F;">NA</span>      GPL-3   plotrix <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 6</span> ABCopt… 0.15.0  <span style="color: #DC322F;">NA</span>      testth… MIT + … Rcpp, … Rcpp    ABCo… <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 7</span> ABCp2   1.2     MASS    <span style="color: #DC322F;">NA</span>      GPL-2   <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 8</span> ABHgen… 1.0.1   <span style="color: #DC322F;">NA</span>      knitr,… GPL-3   ggplot… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;"> 9</span> ABPS    0.3     <span style="color: #DC322F;">NA</span>      testth… GPL (&gt;… kernlab <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;">10</span> ACA     1.1     R (&gt;= … <span style="color: #DC322F;">NA</span>      GPL     graphi… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #999999;"># … with 45,269 more rows, 23 more variables:</span>                           
-#> <span style="color: #999999;">#   license_restricts_use &lt;chr&gt;, os_type &lt;chr&gt;, priority &lt;chr&gt;,</span>         
-#> <span style="color: #999999;">#   license_is_foss &lt;chr&gt;, repodir &lt;chr&gt;, rversion &lt;chr&gt;,</span>               
-#> <span style="color: #999999;">#   platform &lt;chr&gt;, needscompilation &lt;chr&gt;, ref &lt;chr&gt;, type &lt;chr&gt;,</span>      
-#> <span style="color: #999999;">#   direct &lt;lgl&gt;, status &lt;chr&gt;, target &lt;chr&gt;, mirror &lt;chr&gt;,</span>             
-#> <span style="color: #999999;">#   sources &lt;list&gt;, filesize &lt;int&gt;, sha256 &lt;chr&gt;, sysreqs &lt;chr&gt;,</span>        
-#> <span style="color: #999999;">#   built &lt;chr&gt;, published &lt;dttm&gt;, deps &lt;list&gt;, md5sum &lt;chr&gt;, …</span>         
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{meta_list()
+}\if{html}{\out{</div>}}
 
 Selected packages only:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{meta_list(pkg = c("shiny", "htmlwidgets"))
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>   package  version depends sugge…¹ license imports linki…² archs enhan…³
-#> <span style="color: #c2c2c2;">*</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>    <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  
-#> <span style="color: #c2c2c2;">1</span> htmlwid… 1.5.4   <span style="color: #DC322F;">NA</span>      <span style="color: #999999;">"</span>knitr… MIT + … <span style="color: #999999;">"</span>grDev… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    shiny …
-#> <span style="color: #c2c2c2;">2</span> shiny    1.7.3   R (&gt;= … <span style="color: #999999;">"</span>datas… GPL-3 … <span style="color: #999999;">"</span>utils… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;">3</span> htmlwid… 1.6.0   <span style="color: #DC322F;">NA</span>      <span style="color: #999999;">"</span>testt… MIT + … <span style="color: #999999;">"</span>grDev… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    shiny …
-#> <span style="color: #c2c2c2;">4</span> shiny    1.7.4   R (&gt;= … <span style="color: #999999;">"</span>datas… GPL-3 … <span style="color: #999999;">"</span>utils… <span style="color: #DC322F;">NA</span>      <span style="color: #DC322F;">NA</span>    <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #999999;"># … with 23 more variables: license_restricts_use &lt;chr&gt;, os_type &lt;chr&gt;,</span> 
-#> <span style="color: #999999;">#   priority &lt;chr&gt;, license_is_foss &lt;chr&gt;, repodir &lt;chr&gt;,</span>               
-#> <span style="color: #999999;">#   rversion &lt;chr&gt;, platform &lt;chr&gt;, needscompilation &lt;chr&gt;, ref &lt;chr&gt;,</span>  
-#> <span style="color: #999999;">#   type &lt;chr&gt;, direct &lt;lgl&gt;, status &lt;chr&gt;, target &lt;chr&gt;, mirror &lt;chr&gt;,</span> 
-#> <span style="color: #999999;">#   sources &lt;list&gt;, filesize &lt;int&gt;, sha256 &lt;chr&gt;, sysreqs &lt;chr&gt;,</span>        
-#> <span style="color: #999999;">#   built &lt;chr&gt;, published &lt;dttm&gt;, deps &lt;list&gt;, md5sum &lt;chr&gt;,</span>           
-#> <span style="color: #999999;">#   path &lt;chr&gt;, and abbreviated variable names ¹​suggests, ²​linkingto, </span>
-#> <span style="color: #999999;">…</span>                                                                      <span style="color: #999999;"> </span>
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{meta_list(pkg = c("shiny", "htmlwidgets"))
+}\if{html}{\out{</div>}}
 
 
 Update the metadata DB
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{meta_update()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #859900;">✔</span> Updated metadata database: 1.23 MB in 1 file.                         
-#> <span style="color: #859900;">✔</span> Updating metadata database ... done                                   
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{meta_update()
+}\if{html}{\out{</div>}}
 
 
 Delete the metadata DB
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{meta_clean()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #2AA198;">ℹ</span> Cleaning up cache directory <span style="color: #268BD2;">/Users/gaborcsardi/Library/Caches/org.R-pr</span>
-#> <span style="color: #268BD2;">oject.R/R/pkgcache/_metadata</span>.                                          <span style="color: #268BD2;"> </span>
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{meta_clean()
+}\if{html}{\out{</div>}}
 }
 

--- a/man/pak_sitrep.Rd
+++ b/man/pak_sitrep.Rd
@@ -20,27 +20,8 @@ It prints
 \section{Examples}{
 
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pak_sitrep()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>  compatible)                                                            
-#> - pak repository: - (local install?)                                    
-#> * Optional packages installed:                                          
-#> - pillar                                                                
-#> * Library path:                                                         
-#> - /private/var/folders/ph/fpcmzfd16rgbbk8mxvy9m2_h0000gn/T/RtmpcpVAdU/fi
-#> led8ef3d7a46fc                                                          
-#> - /private/var/folders/ph/fpcmzfd16rgbbk8mxvy9m2_h0000gn/T/RtmpcpVAdU/fi
-#> led8ef2562d6ef                                                          
-#> - /Users/gaborcsardi/Library/R/arm64/4.2/library                        
-#> - /Library/Frameworks/R.framework/Versions/4.2-arm64/Resources/library  
-#> * Private library location:                                             
-#> - /Users/gaborcsardi/Library/Caches/org.R-project.R/R/pak/lib/4.2/aarch6
-#> 4                                                                       
-#> * Private library exists.                                               
-#> * Private library is functional                                         
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pak_sitrep()
+}\if{html}{\out{</div>}}
 }
 
 \seealso{

--- a/man/pkg_deps.Rd
+++ b/man/pkg_deps.Rd
@@ -9,12 +9,12 @@ pkg_deps(pkg, upgrade = TRUE, dependencies = NA)
 \arguments{
 \item{pkg}{Package names or package references. E.g.
 \itemize{
-\item \code{ggplot2}: package from CRAN, Bioconductor or a CRAN-like repository
+\item \code{ggplot2} or \code{cran::ggplot2}: package from CRAN, Bioconductor or a CRAN-like repository
 in general,
-\item \code{tidyverse/ggplot2}: package from GitHub,
-\item \code{tidyverse/ggplot2@v3.4.0}: package from GitHub tag or branch,
-\item \verb{https://examples.com/.../ggplot2_3.3.6.tar.gz}: package from URL,
-\item \code{.}: package in the current working directory.
+\item \code{tidyverse/ggplot2} or \code{github::tidyverse/ggplot2}: package from GitHub,
+\item \code{tidyverse/ggplot2@v3.4.0} or \code{github::tidyverse/ggplot2@v3.4.0}: package from GitHub tag or branch,
+\item \verb{url::https://examples.com/.../ggplot2_3.3.6.tar.gz}: package from URL,
+\item \code{.} or \code{local::.}: package in the current working directory.
 }
 
 See "\link{Package sources}" for more details.}
@@ -45,60 +45,13 @@ Look up the dependencies of a package
 \section{Examples}{
 
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pkg_deps("dplyr")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 16 × 32</span>                                                 
-#>    ref       type  direct direc…¹ status package version license needs…²
-#>    <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>     <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;lgl&gt;</span>  <span style="font-style: italic;color: #999999;">&lt;lgl&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;lgl&gt;</span>  
-#> <span style="color: #c2c2c2;"> 1</span> R6        stan… FALSE  FALSE   OK     R6      2.5.1   MIT + … FALSE  
-#> <span style="color: #c2c2c2;"> 2</span> cli       stan… FALSE  FALSE   OK     cli     3.4.1   MIT + … FALSE  
-#> <span style="color: #c2c2c2;"> 3</span> dplyr     stan… TRUE   TRUE    OK     dplyr   1.0.10  MIT + … FALSE  
-#> <span style="color: #c2c2c2;"> 4</span> fansi     stan… FALSE  FALSE   OK     fansi   1.0.3   GPL-2 … FALSE  
-#> <span style="color: #c2c2c2;"> 5</span> generics  stan… FALSE  FALSE   OK     generi… 0.1.3   MIT + … FALSE  
-#> <span style="color: #c2c2c2;"> 6</span> glue      stan… FALSE  FALSE   OK     glue    1.6.2   MIT + … FALSE  
-#> <span style="color: #c2c2c2;"> 7</span> lifecycle stan… FALSE  FALSE   OK     lifecy… 1.0.3   MIT + … FALSE  
-#> <span style="color: #c2c2c2;"> 8</span> magrittr  stan… FALSE  FALSE   OK     magrit… 2.0.3   MIT + … FALSE  
-#> <span style="color: #c2c2c2;"> 9</span> pillar    stan… FALSE  FALSE   OK     pillar  1.8.1   MIT + … FALSE  
-#> <span style="color: #c2c2c2;">10</span> pkgconfig stan… FALSE  FALSE   OK     pkgcon… 2.0.3   MIT + … FALSE  
-#> <span style="color: #c2c2c2;">11</span> rlang     stan… FALSE  FALSE   OK     rlang   1.0.6   MIT + … FALSE  
-#> <span style="color: #c2c2c2;">12</span> tibble    stan… FALSE  FALSE   OK     tibble  3.1.8   MIT + … FALSE  
-#> <span style="color: #c2c2c2;">13</span> tidysele… stan… FALSE  FALSE   OK     tidyse… 1.2.0   MIT + … FALSE  
-#> <span style="color: #c2c2c2;">14</span> utf8      stan… FALSE  FALSE   OK     utf8    1.2.2   Apache… FALSE  
-#> <span style="color: #c2c2c2;">15</span> vctrs     stan… FALSE  FALSE   OK     vctrs   0.5.1   MIT + … FALSE  
-#> <span style="color: #c2c2c2;">16</span> withr     stan… FALSE  FALSE   OK     withr   2.5.0   MIT + … FALSE  
-#> <span style="color: #999999;"># … with 23 more variables: priority &lt;chr&gt;, md5sum &lt;chr&gt;, sha256 &lt;chr&gt;,</span> 
-#> <span style="color: #999999;">#   filesize &lt;int&gt;, built &lt;chr&gt;, platform &lt;chr&gt;, rversion &lt;chr&gt;,</span>        
-#> <span style="color: #999999;">#   repotype &lt;chr&gt;, repodir &lt;chr&gt;, target &lt;chr&gt;, deps &lt;list&gt;,</span>           
-#> <span style="color: #999999;">#   mirror &lt;chr&gt;, sources &lt;list&gt;, remote &lt;list&gt;, error &lt;list&gt;,</span>          
-#> <span style="color: #999999;">#   metadata &lt;list&gt;, dep_types &lt;list&gt;, params &lt;list&gt;, sysreqs &lt;chr&gt;,</span>    
-#> <span style="color: #999999;">#   cache_status &lt;chr&gt;, lib_status &lt;chr&gt;, old_version &lt;chr&gt;,</span>            
-#> <span style="color: #999999;">#   new_version &lt;chr&gt;, and abbreviated variable names ¹​directpkg, …</span>    
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pkg_deps("dplyr")
+}\if{html}{\out{</div>}}
 
 For a package on GitHub:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pkg_deps("r-lib/callr")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 4 × 32</span>                                                  
-#>   ref        type  direct direc…¹ status package version license needs…²
-#>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>      <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;lgl&gt;</span>  <span style="font-style: italic;color: #999999;">&lt;lgl&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;lgl&gt;</span>  
-#> <span style="color: #c2c2c2;">1</span> r-lib/cal… gith… TRUE   TRUE    OK     callr   3.7.3.… MIT + … TRUE   
-#> <span style="color: #c2c2c2;">2</span> R6         stan… FALSE  FALSE   OK     R6      2.5.1   MIT + … FALSE  
-#> <span style="color: #c2c2c2;">3</span> processx   stan… FALSE  FALSE   OK     proces… 3.8.0   MIT + … FALSE  
-#> <span style="color: #c2c2c2;">4</span> ps         stan… FALSE  FALSE   OK     ps      1.7.2   MIT + … FALSE  
-#> <span style="color: #999999;"># … with 23 more variables: priority &lt;chr&gt;, md5sum &lt;chr&gt;, sha256 &lt;chr&gt;,</span> 
-#> <span style="color: #999999;">#   filesize &lt;int&gt;, built &lt;chr&gt;, platform &lt;chr&gt;, rversion &lt;chr&gt;,</span>        
-#> <span style="color: #999999;">#   repotype &lt;chr&gt;, repodir &lt;chr&gt;, target &lt;chr&gt;, deps &lt;list&gt;,</span>           
-#> <span style="color: #999999;">#   mirror &lt;chr&gt;, sources &lt;list&gt;, remote &lt;list&gt;, error &lt;list&gt;,</span>          
-#> <span style="color: #999999;">#   metadata &lt;list&gt;, dep_types &lt;list&gt;, params &lt;list&gt;, sysreqs &lt;chr&gt;,</span>    
-#> <span style="color: #999999;">#   cache_status &lt;chr&gt;, lib_status &lt;chr&gt;, old_version &lt;chr&gt;,</span>            
-#> <span style="color: #999999;">#   new_version &lt;chr&gt;, and abbreviated variable names ¹​directpkg, …</span>    
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pkg_deps("r-lib/callr")
+}\if{html}{\out{</div>}}
 }
 
 \seealso{

--- a/man/pkg_deps_explain.Rd
+++ b/man/pkg_deps_explain.Rd
@@ -9,12 +9,12 @@ pkg_deps_explain(pkg, deps, upgrade = TRUE, dependencies = NA)
 \arguments{
 \item{pkg}{Package names or package references. E.g.
 \itemize{
-\item \code{ggplot2}: package from CRAN, Bioconductor or a CRAN-like repository
+\item \code{ggplot2} or \code{cran::ggplot2}: package from CRAN, Bioconductor or a CRAN-like repository
 in general,
-\item \code{tidyverse/ggplot2}: package from GitHub,
-\item \code{tidyverse/ggplot2@v3.4.0}: package from GitHub tag or branch,
-\item \verb{https://examples.com/.../ggplot2_3.3.6.tar.gz}: package from URL,
-\item \code{.}: package in the current working directory.
+\item \code{tidyverse/ggplot2} or \code{github::tidyverse/ggplot2}: package from GitHub,
+\item \code{tidyverse/ggplot2@v3.4.0} or \code{github::tidyverse/ggplot2@v3.4.0}: package from GitHub tag or branch,
+\item \verb{url::https://examples.com/.../ggplot2_3.3.6.tar.gz}: package from URL,
+\item \code{.} or \code{local::.}: package in the current working directory.
 }
 
 See "\link{Package sources}" for more details.}
@@ -53,47 +53,12 @@ to read if you are only interested is certain packages (\code{deps}).
 
 How does dplyr depend on rlang?
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pkg_deps_explain("dplyr", "rlang")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #859900;">✔</span> Updated metadata database: 5.09 MB in 12 files.                       
-#> <span style="color: #859900;">✔</span> Updating metadata database ... done                                   
-#> dplyr -&gt; lifecycle -&gt; rlang                                             
-#> dplyr -&gt; rlang                                                          
-#> dplyr -&gt; tibble -&gt; lifecycle -&gt; rlang                                   
-#> dplyr -&gt; tibble -&gt; pillar -&gt; lifecycle -&gt; rlang                         
-#> dplyr -&gt; tibble -&gt; pillar -&gt; rlang                                      
-#> dplyr -&gt; tibble -&gt; pillar -&gt; vctrs -&gt; lifecycle -&gt; rlang                
-#> dplyr -&gt; tibble -&gt; pillar -&gt; vctrs -&gt; rlang                             
-#> dplyr -&gt; tibble -&gt; rlang                                                
-#> dplyr -&gt; tibble -&gt; vctrs -&gt; lifecycle -&gt; rlang                          
-#> dplyr -&gt; tibble -&gt; vctrs -&gt; rlang                                       
-#> dplyr -&gt; tidyselect -&gt; lifecycle -&gt; rlang                               
-#> dplyr -&gt; tidyselect -&gt; rlang                                            
-#> dplyr -&gt; tidyselect -&gt; vctrs -&gt; lifecycle -&gt; rlang                      
-#> dplyr -&gt; tidyselect -&gt; vctrs -&gt; rlang                                   
-#> dplyr -&gt; vctrs -&gt; lifecycle -&gt; rlang                                    
-#> dplyr -&gt; vctrs -&gt; rlang                                                 
-#> dplyr -&gt; pillar -&gt; lifecycle -&gt; rlang                                   
-#> dplyr -&gt; pillar -&gt; rlang                                                
-#> dplyr -&gt; pillar -&gt; vctrs -&gt; lifecycle -&gt; rlang                          
-#> dplyr -&gt; pillar -&gt; vctrs -&gt; rlang                                       
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pkg_deps_explain("dplyr", "rlang")
+}\if{html}{\out{</div>}}
 
 How does the GH version of usethis depend on cli and ps?
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pkg_deps_explain("r-lib/usethis", c("cli", "ps"))
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> usethis -&gt; cli                                                          
-#> usethis -&gt; desc -&gt; cli                                                  
-#> usethis -&gt; gh -&gt; cli                                                    
-#> usethis -&gt; lifecycle -&gt; cli                                             
-#>                                                                         
-#> x ps                                                                    
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pkg_deps_explain("r-lib/usethis", c("cli", "ps"))
+}\if{html}{\out{</div>}}
 }
 

--- a/man/pkg_deps_tree.Rd
+++ b/man/pkg_deps_tree.Rd
@@ -9,12 +9,12 @@ pkg_deps_tree(pkg, upgrade = TRUE, dependencies = NA)
 \arguments{
 \item{pkg}{Package names or package references. E.g.
 \itemize{
-\item \code{ggplot2}: package from CRAN, Bioconductor or a CRAN-like repository
+\item \code{ggplot2} or \code{cran::ggplot2}: package from CRAN, Bioconductor or a CRAN-like repository
 in general,
-\item \code{tidyverse/ggplot2}: package from GitHub,
-\item \code{tidyverse/ggplot2@v3.4.0}: package from GitHub tag or branch,
-\item \verb{https://examples.com/.../ggplot2_3.3.6.tar.gz}: package from URL,
-\item \code{.}: package in the current working directory.
+\item \code{tidyverse/ggplot2} or \code{github::tidyverse/ggplot2}: package from GitHub,
+\item \code{tidyverse/ggplot2@v3.4.0} or \code{github::tidyverse/ggplot2@v3.4.0}: package from GitHub tag or branch,
+\item \verb{url::https://examples.com/.../ggplot2_3.3.6.tar.gz}: package from URL,
+\item \code{.} or \code{local::.}: package in the current working directory.
 }
 
 See "\link{Package sources}" for more details.}
@@ -43,111 +43,11 @@ Draw the dependency tree of a package
 \section{Examples}{
 
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pkg_deps_tree("dplyr")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="font-weight: bold;font-style: italic;color: #2AA198;">dplyr </span><span style="font-weight: bold;font-style: italic;color: #525252;">1.0.10</span> <span style="color: #859900;">✨</span>                                                          
-#> ├─generics <span style="color: #525252;">0.1.3</span> <span style="color: #859900;">✨</span>                                                      
-#> ├─glue <span style="color: #525252;">1.6.2</span> <span style="color: #859900;">✨</span>                                                          
-#> ├─lifecycle <span style="color: #525252;">1.0.3</span> <span style="color: #859900;">✨</span>                                                     
-#> │ ├─cli <span style="color: #525252;">3.4.1</span> <span style="color: #859900;">✨</span>                                                         
-#> │ ├─glue                                                                
-#> │ └─rlang <span style="color: #525252;">1.0.6</span> <span style="color: #859900;">✨</span>                                                       
-#> ├─magrittr <span style="color: #525252;">2.0.3</span> <span style="color: #859900;">✨</span>                                                      
-#> ├─R6 <span style="color: #525252;">2.5.1</span> <span style="color: #859900;">✨</span>                                                            
-#> ├─rlang                                                                 
-#> ├─tibble <span style="color: #525252;">3.1.8</span> <span style="color: #859900;">✨</span>                                                        
-#> │ ├─fansi <span style="color: #525252;">1.0.3</span> <span style="color: #859900;">✨</span>                                                       
-#> │ ├─lifecycle                                                           
-#> │ ├─magrittr                                                            
-#> │ ├─pillar <span style="color: #525252;">1.8.1</span> <span style="color: #859900;">✨</span>                                                      
-#> │ │ ├─cli                                                               
-#> │ │ ├─fansi                                                             
-#> │ │ ├─glue                                                              
-#> │ │ ├─lifecycle                                                         
-#> │ │ ├─rlang                                                             
-#> │ │ ├─utf8 <span style="color: #525252;">1.2.2</span> <span style="color: #859900;">✨</span>                                                      
-#> │ │ └─vctrs <span style="color: #525252;">0.5.1</span> <span style="color: #859900;">✨</span>                                                     
-#> │ │   ├─cli                                                             
-#> │ │   ├─glue                                                            
-#> │ │   ├─lifecycle                                                       
-#> │ │   └─rlang                                                           
-#> │ ├─pkgconfig <span style="color: #525252;">2.0.3</span> <span style="color: #859900;">✨</span>                                                   
-#> │ ├─rlang                                                               
-#> │ └─vctrs                                                               
-#> ├─tidyselect <span style="color: #525252;">1.2.0</span> <span style="color: #859900;">✨</span>                                                    
-#> │ ├─cli                                                                 
-#> │ ├─glue                                                                
-#> │ ├─lifecycle                                                           
-#> │ ├─rlang                                                               
-#> │ ├─vctrs                                                               
-#> │ └─withr <span style="color: #525252;">2.5.0</span> <span style="color: #859900;">✨</span>                                                       
-#> ├─vctrs                                                                 
-#> └─pillar                                                                
-#>                                                                         
-#> Key:  <span style="color: #859900;">✨</span> new                                                             
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pkg_deps_tree("dplyr")
+}\if{html}{\out{</div>}}
 
-
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pkg_deps_tree("r-lib/usethis")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="font-weight: bold;font-style: italic;color: #2AA198;">r-lib/usethis </span><span style="font-weight: bold;font-style: italic;color: #525252;">2.1.6.9000</span> <span style="color: #859900;">✨👷🏼🔧 </span>                                          
-#> ├─cli <span style="color: #525252;">3.4.1</span> <span style="color: #859900;">✨</span>                                                           
-#> ├─clipr <span style="color: #525252;">0.8.0</span> <span style="color: #859900;">✨</span>                                                         
-#> ├─crayon <span style="color: #525252;">1.5.2</span> <span style="color: #859900;">✨</span>                                                        
-#> ├─curl <span style="color: #525252;">4.3.3</span> <span style="color: #859900;">✨</span>                                                          
-#> ├─desc <span style="color: #525252;">1.4.2</span> <span style="color: #859900;">✨</span>                                                          
-#> │ ├─cli                                                                 
-#> │ ├─R6 <span style="color: #525252;">2.5.1</span> <span style="color: #859900;">✨</span>                                                          
-#> │ └─rprojroot <span style="color: #525252;">2.0.3</span> <span style="color: #859900;">✨</span>                                                   
-#> ├─fs <span style="color: #525252;">1.5.2</span> <span style="color: #859900;">✨</span>                                                            
-#> ├─gert <span style="color: #525252;">1.9.2</span> <span style="color: #859900;">✨ ⬇ </span><span style="color: #525252;">(1.91 MB)</span>                                              
-#> │ ├─askpass <span style="color: #525252;">1.1</span> <span style="color: #859900;">✨</span>                                                       
-#> │ │ └─sys <span style="color: #525252;">3.4.1</span> <span style="color: #859900;">✨</span>                                                       
-#> │ ├─credentials <span style="color: #525252;">1.3.2</span> <span style="color: #859900;">✨ ⬇ </span><span style="color: #525252;">(170.15 kB)</span>                                   
-#> │ │ ├─openssl <span style="color: #525252;">2.0.5</span> <span style="color: #859900;">✨</span>                                                   
-#> │ │ │ └─askpass                                                         
-#> │ │ ├─sys                                                               
-#> │ │ ├─curl                                                              
-#> │ │ ├─jsonlite <span style="color: #525252;">1.8.4</span> <span style="color: #859900;">✨</span>                                                  
-#> │ │ └─askpass                                                           
-#> │ ├─openssl                                                             
-#> │ ├─rstudioapi <span style="color: #525252;">0.14</span> <span style="color: #859900;">✨</span>                                                   
-#> │ ├─sys                                                                 
-#> │ └─zip <span style="color: #525252;">2.2.2</span> <span style="color: #859900;">✨</span>                                                         
-#> ├─gh <span style="color: #525252;">1.3.1</span> <span style="color: #859900;">✨ ⬇ </span><span style="color: #525252;">(95.20 kB)</span>                                               
-#> │ ├─cli                                                                 
-#> │ ├─gitcreds <span style="color: #525252;">0.1.2</span> <span style="color: #859900;">✨ ⬇ </span><span style="color: #525252;">(95.59 kB)</span>                                       
-#> │ ├─httr <span style="color: #525252;">1.4.4</span> <span style="color: #859900;">✨</span>                                                        
-#> │ │ ├─curl                                                              
-#> │ │ ├─jsonlite                                                          
-#> │ │ ├─mime <span style="color: #525252;">0.12</span> <span style="color: #859900;">✨</span>                                                       
-#> │ │ ├─openssl                                                           
-#> │ │ └─R6                                                                
-#> │ ├─ini <span style="color: #525252;">0.3.1</span> <span style="color: #859900;">✨ ⬇ </span><span style="color: #525252;">(13.13 kB)</span>                                            
-#> │ └─jsonlite                                                            
-#> ├─glue <span style="color: #525252;">1.6.2</span> <span style="color: #859900;">✨</span>                                                          
-#> ├─jsonlite                                                              
-#> ├─lifecycle <span style="color: #525252;">1.0.3</span> <span style="color: #859900;">✨</span>                                                     
-#> │ ├─cli                                                                 
-#> │ ├─glue                                                                
-#> │ └─rlang <span style="color: #525252;">1.0.6</span> <span style="color: #859900;">✨</span>                                                       
-#> ├─purrr <span style="color: #525252;">0.3.5</span> <span style="color: #859900;">✨</span>                                                         
-#> │ ├─magrittr <span style="color: #525252;">2.0.3</span> <span style="color: #859900;">✨</span>                                                    
-#> │ └─rlang                                                               
-#> ├─rappdirs <span style="color: #525252;">0.3.3</span> <span style="color: #859900;">✨</span>                                                      
-#> ├─rlang                                                                 
-#> ├─rprojroot                                                             
-#> ├─rstudioapi                                                            
-#> ├─whisker <span style="color: #525252;">0.4.1</span> <span style="color: #859900;">✨ ⬇ </span><span style="color: #525252;">(65.36 kB)</span>                                          
-#> ├─withr <span style="color: #525252;">2.5.0</span> <span style="color: #859900;">✨</span>                                                         
-#> └─yaml <span style="color: #525252;">2.3.6</span> <span style="color: #859900;">✨</span>                                                          
-#>                                                                         
-#> Key:  <span style="color: #859900;">✨</span> new | <span style="color: #859900;"> ⬇</span> download | <span style="color: #859900;">👷🏼 </span>build | 🔧<span style="color: #859900;"> </span>compile                        
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pkg_deps_tree("r-lib/usethis")
+}\if{html}{\out{</div>}}
 }
 
 \seealso{

--- a/man/pkg_download.Rd
+++ b/man/pkg_download.Rd
@@ -15,12 +15,12 @@ pkg_download(
 \arguments{
 \item{pkg}{Package names or package references. E.g.
 \itemize{
-\item \code{ggplot2}: package from CRAN, Bioconductor or a CRAN-like repository
+\item \code{ggplot2} or \code{cran::ggplot2}: package from CRAN, Bioconductor or a CRAN-like repository
 in general,
-\item \code{tidyverse/ggplot2}: package from GitHub,
-\item \code{tidyverse/ggplot2@v3.4.0}: package from GitHub tag or branch,
-\item \verb{https://examples.com/.../ggplot2_3.3.6.tar.gz}: package from URL,
-\item \code{.}: package in the current working directory.
+\item \code{tidyverse/ggplot2} or \code{github::tidyverse/ggplot2}: package from GitHub,
+\item \code{tidyverse/ggplot2@v3.4.0} or \code{github::tidyverse/ggplot2@v3.4.0}: package from GitHub tag or branch,
+\item \verb{url::https://examples.com/.../ggplot2_3.3.6.tar.gz}: package from URL,
+\item \code{.} or \code{local::.}: package in the current working directory.
 }
 
 See "\link{Package sources}" for more details.}
@@ -58,48 +58,17 @@ TODO: explain result
 \section{Examples}{
 
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{dl <- pkg_download("forcats")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed, 2 pkgs (641.53 kB) are cached                
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{dl <- pkg_download("forcats")
+}\if{html}{\out{</div>}}
 
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{dl
+}\if{html}{\out{</div>}}
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{dl
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 2 × 35</span>                                                  
-#>   ref     type     direct direc…¹ status package version license needs…²
-#>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>    <span style="font-style: italic;color: #999999;">&lt;lgl&gt;</span>  <span style="font-style: italic;color: #999999;">&lt;lgl&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;lgl&gt;</span>  
-#> <span style="color: #c2c2c2;">1</span> forcats standard TRUE   TRUE    OK     forcats 0.5.2   MIT + … FALSE  
-#> <span style="color: #c2c2c2;">2</span> forcats standard TRUE   TRUE    OK     forcats 0.5.2   MIT + … FALSE  
-#> <span style="color: #999999;"># … with 26 more variables: priority &lt;chr&gt;, md5sum &lt;chr&gt;, sha256 &lt;chr&gt;,</span> 
-#> <span style="color: #999999;">#   filesize &lt;int&gt;, built &lt;chr&gt;, platform &lt;chr&gt;, rversion &lt;chr&gt;,</span>        
-#> <span style="color: #999999;">#   repotype &lt;chr&gt;, repodir &lt;chr&gt;, target &lt;chr&gt;, deps &lt;list&gt;,</span>           
-#> <span style="color: #999999;">#   mirror &lt;chr&gt;, sources &lt;list&gt;, remote &lt;list&gt;, error &lt;list&gt;,</span>          
-#> <span style="color: #999999;">#   metadata &lt;list&gt;, extra &lt;list&gt;, dep_types &lt;list&gt;, params &lt;list&gt;,</span>     
-#> <span style="color: #999999;">#   sysreqs &lt;chr&gt;, cache_status &lt;chr&gt;, fulltarget &lt;chr&gt;,</span>                
-#> <span style="color: #999999;">#   fulltarget_tree &lt;chr&gt;, download_status &lt;chr&gt;, …</span>                     
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{dl$fulltarget
+}\if{html}{\out{</div>}}
 
-
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{dl$fulltarget
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> [1] "./bin/macosx/big-sur-arm64/contrib/4.2/forcats_0.5.2.tgz"          
-#> [2] "./src/contrib/forcats_0.5.2.tar.gz"                                
-</pre></div>
-}}
-
-
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pkg_download("r-lib/pak", platforms = "source")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed, 1 pkg is cached                              
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pkg_download("r-lib/pak", platforms = "source")
+}\if{html}{\out{</div>}}
 }
 
 \seealso{

--- a/man/pkg_history.Rd
+++ b/man/pkg_history.Rd
@@ -20,30 +20,7 @@ Query the history of a CRAN package
 \section{Examples}{
 
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pkg_history("ggplot2")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 44 × 30</span>                                                 
-#>    Package Type    Title    Version Date  Author Maint…¹ Descr…² License
-#>  <span style="color: #c2c2c2;">*</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>    <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  
-#> <span style="color: #c2c2c2;"> 1</span> ggplot2 Package An impl… 0.5     2007… Hadle… Hadley… <span style="color: #999999;">"</span>An im… GPL    
-#> <span style="color: #c2c2c2;"> 2</span> ggplot2 Package An impl… 0.5.1   2007… Hadle… Hadley… <span style="color: #999999;">"</span>An im… GPL    
-#> <span style="color: #c2c2c2;"> 3</span> ggplot2 Package An impl… 0.5.2   2007… Hadle… Hadley… <span style="color: #999999;">"</span>An im… GPL    
-#> <span style="color: #c2c2c2;"> 4</span> ggplot2 Package An impl… 0.5.4   2007… Hadle… Hadley… <span style="color: #999999;">"</span>An im… GPL    
-#> <span style="color: #c2c2c2;"> 5</span> ggplot2 Package An impl… 0.5.5   2007… Hadle… Hadley… <span style="color: #999999;">"</span>An im… GPL    
-#> <span style="color: #c2c2c2;"> 6</span> ggplot2 Package An impl… 0.5.6   2007… Hadle… Hadley… <span style="color: #999999;">"</span>An im… GPL    
-#> <span style="color: #c2c2c2;"> 7</span> ggplot2 Package An impl… 0.5.7   2007… Hadle… Hadley… <span style="color: #999999;">"</span>An im… GPL    
-#> <span style="color: #c2c2c2;"> 8</span> ggplot2 Package An impl… 0.6     2008… Hadle… Hadley… <span style="color: #999999;">"</span>An im… GPL    
-#> <span style="color: #c2c2c2;"> 9</span> ggplot2 Package An impl… 0.7     2008… Hadle… Hadley… <span style="color: #999999;">"</span>An im… GPL    
-#> <span style="color: #c2c2c2;">10</span> ggplot2 Package An impl… 0.8     2008… Hadle… Hadley… <span style="color: #999999;">"</span>An im… GPL    
-#> <span style="color: #999999;"># … with 34 more rows, 21 more variables: SaveImage &lt;chr&gt;,</span>              
-#> <span style="color: #999999;">#   LazyData &lt;chr&gt;, Packaged &lt;chr&gt;, crandb_file_date &lt;chr&gt;, date &lt;chr&gt;,</span> 
-#> <span style="color: #999999;">#   dependencies &lt;list&gt;, URL &lt;chr&gt;, LazyLoad &lt;chr&gt;, Extends &lt;chr&gt;,</span>      
-#> <span style="color: #999999;">#   Collate &lt;chr&gt;, Repository &lt;chr&gt;, `Date/Publication` &lt;chr&gt;,</span>          
-#> <span style="color: #999999;">#   NeedsCompilation &lt;chr&gt;, VignetteBuilder &lt;chr&gt;, BugReports &lt;chr&gt;,</span>    
-#> <span style="color: #999999;">#   `Authors@R` &lt;chr&gt;, RoxygenNote &lt;chr&gt;, Encoding &lt;chr&gt;, MD5sum &lt;chr&gt;,</span> 
-#> <span style="color: #999999;">#   `Config/Needs/website` &lt;chr&gt;, `Config/testthat/edition` &lt;chr&gt;, …</span>    
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pkg_history("ggplot2")
+}\if{html}{\out{</div>}}
 }
 

--- a/man/pkg_install.Rd
+++ b/man/pkg_install.Rd
@@ -15,12 +15,12 @@ pkg_install(
 \arguments{
 \item{pkg}{Package names or package references. E.g.
 \itemize{
-\item \code{ggplot2}: package from CRAN, Bioconductor or a CRAN-like repository
+\item \code{ggplot2} or \code{cran::ggplot2}: package from CRAN, Bioconductor or a CRAN-like repository
 in general,
-\item \code{tidyverse/ggplot2}: package from GitHub,
-\item \code{tidyverse/ggplot2@v3.4.0}: package from GitHub tag or branch,
-\item \verb{https://examples.com/.../ggplot2_3.3.6.tar.gz}: package from URL,
-\item \code{.}: package in the current working directory.
+\item \code{tidyverse/ggplot2} or \code{github::tidyverse/ggplot2}: package from GitHub,
+\item \code{tidyverse/ggplot2@v3.4.0} or \code{github::tidyverse/ggplot2@v3.4.0}: package from GitHub tag or branch,
+\item \verb{url::https://examples.com/.../ggplot2_3.3.6.tar.gz}: package from URL,
+\item \code{.} or \code{local::.}: package in the current working directory.
 }
 
 See "\link{Package sources}" for more details.}
@@ -69,145 +69,24 @@ package library.
 \section{Examples}{
 
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pkg_install("dplyr")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                                                         
-#> → Will <span style="font-style: italic;">install</span> 5 packages.                                              
-#> → All 5 packages (2.14 MB) are cached.                                  
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">dplyr</span>        1.0.9                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">generics</span>     0.1.2                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">purrr</span>        0.3.4                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">R6</span>           2.5.1                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">tidyselect</span>   1.1.2                                                    
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed, 5 pkgs (2.14 MB) are cached                  
-#> <span style="color: #859900;">✔</span> Got <span style="color: #268BD2;">R6</span> 2.5.1 (aarch64-apple-darwin20) (82.52 kB)                      
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">R6</span> 2.5.1  <span style="color: #a3a3a3;">(43ms)</span>                                            
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">generics</span> 0.1.2  <span style="color: #a3a3a3;">(62ms)</span>                                      
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">dplyr</span> 1.0.9  <span style="color: #a3a3a3;">(88ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">purrr</span> 0.3.4  <span style="color: #a3a3a3;">(88ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">tidyselect</span> 1.1.2  <span style="color: #a3a3a3;">(94ms)</span>                                    
-#> <span style="color: #859900;">✔</span> 1 pkg + 17 deps: kept 12, added 5, dld 1 (82.52 kB) <span style="color: #b8b8b8;">[1.2s]</span>            
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pkg_install("dplyr")
+}\if{html}{\out{</div>}}
 
 Upgrade dplyr and all its dependencies:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pkg_install("dplyr", upgrade = TRUE)
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                                                         
-#> → Will <span style="font-style: italic;">update</span> 1 package.                                                
-#> → The package (742.51 kB) is cached.                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">rlang</span> 1.0.2 → 1.0.<span style="font-weight: bold;">3</span> 👷🏿‍♀️🔧                                            
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed, 1 pkg (742.51 kB) is cached                  
-#> <span style="color: #2AA198;">ℹ</span> Building <span style="color: #268BD2;">rlang</span> 1.0.3                                                  
-#> <span style="color: #859900;">✔</span> Built <span style="color: #268BD2;">rlang</span> 1.0.3 <span style="color: #a3a3a3;">(5.8s)</span>                                              
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">rlang</span> 1.0.3  <span style="color: #a3a3a3;">(32ms)</span>                                         
-#> <span style="color: #859900;">✔</span> 1 pkg + 17 deps: kept 17, upd 1 <span style="color: #b8b8b8;">[6.3s]</span>                                
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pkg_install("dplyr", upgrade = TRUE)
+}\if{html}{\out{</div>}}
 
 Install the development version of dplyr:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pkg_install("tidyverse/dplyr")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #859900;">✔</span> Loading metadata database ... done                                    
-#>                                                                         
-#> → Will <span style="font-style: italic;">install</span> 16 packages.                                             
-#> → All 16 packages (8.09 MB) are cached.                                 
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">cli</span>          3.4.1                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">dplyr</span>        1.0.99.9000 👷🏾‍♂️🔧 (GitHub: e6252f8)                     
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">fansi</span>        1.0.3                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">generics</span>     0.1.3                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">glue</span>         1.6.2                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">lifecycle</span>    1.0.3                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">magrittr</span>     2.0.3                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">pillar</span>       1.8.1                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">pkgconfig</span>    2.0.3                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">R6</span>           2.5.1                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">rlang</span>        1.0.6                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">tibble</span>       3.1.8                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">tidyselect</span>   1.2.0                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">utf8</span>         1.2.2                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">vctrs</span>        0.5.1                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">withr</span>        2.5.0                                                    
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed, 16 pkgs (8.09 MB) are cached                 
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">R6</span> 2.5.1  <span style="color: #a3a3a3;">(58ms)</span>                                            
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">cli</span> 3.4.1  <span style="color: #a3a3a3;">(69ms)</span>                                           
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">fansi</span> 1.0.3  <span style="color: #a3a3a3;">(92ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">generics</span> 0.1.3  <span style="color: #a3a3a3;">(99ms)</span>                                      
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">glue</span> 1.6.2  <span style="color: #a3a3a3;">(108ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">lifecycle</span> 1.0.3  <span style="color: #a3a3a3;">(144ms)</span>                                    
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">magrittr</span> 2.0.3  <span style="color: #a3a3a3;">(152ms)</span>                                     
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">pillar</span> 1.8.1  <span style="color: #a3a3a3;">(160ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">pkgconfig</span> 2.0.3  <span style="color: #a3a3a3;">(63ms)</span>                                     
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">rlang</span> 1.0.6  <span style="color: #a3a3a3;">(37ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">tibble</span> 3.1.8  <span style="color: #a3a3a3;">(41ms)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">tidyselect</span> 1.2.0  <span style="color: #a3a3a3;">(38ms)</span>                                    
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">utf8</span> 1.2.2  <span style="color: #a3a3a3;">(36ms)</span>                                          
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">vctrs</span> 0.5.1  <span style="color: #a3a3a3;">(39ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">withr</span> 2.5.0  <span style="color: #a3a3a3;">(30ms)</span>                                         
-#> <span style="color: #2AA198;">ℹ</span> Packaging <span style="color: #268BD2;">dplyr</span> 1.0.99.9000                                           
-#> <span style="color: #859900;">✔</span> Packaged <span style="color: #268BD2;">dplyr</span> 1.0.99.9000 <span style="color: #a3a3a3;">(8.3s)</span>                                     
-#> <span style="color: #2AA198;">ℹ</span> Building <span style="color: #268BD2;">dplyr</span> 1.0.99.9000                                            
-#> <span style="color: #859900;">✔</span> Built <span style="color: #268BD2;">dplyr</span> 1.0.99.9000 <span style="color: #a3a3a3;">(5.2s)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">dplyr</span> 1.0.99.9000 (github::tidyverse/dplyr@e6252f8) <span style="color: #a3a3a3;">(24ms)</span>  
-#> <span style="color: #859900;">✔</span> 1 pkg + 15 deps: added 16 <span style="color: #b8b8b8;">[18.9s]</span>                                     
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pkg_install("tidyverse/dplyr")
+}\if{html}{\out{</div>}}
 
 Switch back to the CRAN version. This will be fast because
 pak will have cached the prior install.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pkg_install("dplyr")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #859900;">✔</span> Updated metadata database: 2.43 MB in 6 files.                        
-#> <span style="color: #859900;">✔</span> Updating metadata database ... done                                   
-#>                                                                         
-#> → Will <span style="font-style: italic;">install</span> 16 packages.                                             
-#> → All 16 packages (9.42 MB) are cached.                                 
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">cli</span>          3.4.1                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">dplyr</span>        1.0.10                                                   
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">fansi</span>        1.0.3                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">generics</span>     0.1.3                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">glue</span>         1.6.2                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">lifecycle</span>    1.0.3                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">magrittr</span>     2.0.3                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">pillar</span>       1.8.1                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">pkgconfig</span>    2.0.3                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">R6</span>           2.5.1                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">rlang</span>        1.0.6                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">tibble</span>       3.1.8                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">tidyselect</span>   1.2.0                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">utf8</span>         1.2.2                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">vctrs</span>        0.5.1                                                    
-#> <span style="color: #525252;">+ </span><span style="color: #268BD2;">withr</span>        2.5.0                                                    
-#> <span style="color: #2AA198;">ℹ</span> No downloads are needed, 16 pkgs (9.42 MB) are cached                 
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">R6</span> 2.5.1  <span style="color: #a3a3a3;">(66ms)</span>                                            
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">cli</span> 3.4.1  <span style="color: #a3a3a3;">(76ms)</span>                                           
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">dplyr</span> 1.0.10  <span style="color: #a3a3a3;">(111ms)</span>                                       
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">fansi</span> 1.0.3  <span style="color: #a3a3a3;">(119ms)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">generics</span> 0.1.3  <span style="color: #a3a3a3;">(125ms)</span>                                     
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">glue</span> 1.6.2  <span style="color: #a3a3a3;">(132ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">lifecycle</span> 1.0.3  <span style="color: #a3a3a3;">(149ms)</span>                                    
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">magrittr</span> 2.0.3  <span style="color: #a3a3a3;">(162ms)</span>                                     
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">pillar</span> 1.8.1  <span style="color: #a3a3a3;">(56ms)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">pkgconfig</span> 2.0.3  <span style="color: #a3a3a3;">(35ms)</span>                                     
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">rlang</span> 1.0.6  <span style="color: #a3a3a3;">(57ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">tibble</span> 3.1.8  <span style="color: #a3a3a3;">(41ms)</span>                                        
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">tidyselect</span> 1.2.0  <span style="color: #a3a3a3;">(40ms)</span>                                    
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">utf8</span> 1.2.2  <span style="color: #a3a3a3;">(37ms)</span>                                          
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">vctrs</span> 0.5.1  <span style="color: #a3a3a3;">(39ms)</span>                                         
-#> <span style="color: #859900;">✔</span> Installed <span style="color: #268BD2;">withr</span> 2.5.0  <span style="color: #a3a3a3;">(31ms)</span>                                         
-#> <span style="color: #859900;">✔</span> 1 pkg + 15 deps: added 16 <span style="color: #b8b8b8;">[7.2s]</span>                                      
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pkg_install("dplyr")
+}\if{html}{\out{</div>}}
 }
 
 \seealso{

--- a/man/pkg_name_check.Rd
+++ b/man/pkg_name_check.Rd
@@ -59,32 +59,7 @@ See the \code{dictionaries} argument.
 \section{Examples}{
 
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pkg_name_check("sicily")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #B58900;">╔══════════════════════════════════════════════════════════════════════╗</span>
-#> <span style="color: #B58900;">║</span>                            <span style="color: #B58900;">–*–</span> <span style="font-weight: bold;color: #268BD2;">sicily</span> <span style="color: #B58900;">–*–</span>                            <span style="color: #B58900;">║</span>
-#> <span style="color: #B58900;">╚══════════════════════════════════════════════════════════════════════╝</span>
-#> <span style="color: #525252;">┌──────────────────────────────────────────────────────────────────────┐</span>
-#> <span style="color: #525252;">│</span> <span style="color: #859900;">✔</span>  valid name          <span style="color: #859900;">✔</span>  CRAN               <span style="color: #859900;">✔</span>  Bioconductor         <span style="color: #525252;">│</span>
-#> <span style="color: #525252;">│</span> <span style="color: #859900;">✔</span>  not a profanity                                                   <span style="color: #525252;">│</span>
-#> <span style="color: #525252;">└──────────────────────────────────────────────────────────────────────┘</span>
-#> <span style="color: #525252;">┌ </span><span style="color: #859900;">Wikipedia</span><span style="color: #525252;"> ───────────────────────────────────────────────────────────┐</span>
-#> <span style="color: #525252;">│</span> <span style="text-decoration: underline;">Sicily</span> Sicily (Italian: Sicilia [siˈtʃiːlja], Sicilian               <span style="color: #525252;">│</span>
-#> <span style="color: #525252;">│</span> pronunciation: [sɪˈʃiːlja]) is the largest island in the             <span style="color: #525252;">│</span>
-#> <span style="color: #525252;">│</span> Mediterranean Sea and one of the 20 regions of Italy. The Strait of  <span style="color: #525252;">│</span>
-#> <span style="color: #525252;">│</span> Messina divides it from the region of Calabria in Southern Italy.    <span style="color: #525252;">│</span>
-#> <span style="color: #525252;">│</span> It is one of the five Italian autonomous regions and is officially   <span style="color: #525252;">│</span>
-#> <span style="color: #525252;">│</span> referred to as Regione Siciliana. The region has 5 million           <span style="color: #525252;">│</span>
-#> <span style="color: #525252;">│</span> …                                                                    <span style="color: #525252;">│</span>
-#> <span style="color: #525252;">└──────────────────────────────── </span><span style="color: #268BD2;">https://en.wikipedia.org/wiki/Sicily</span><span style="color: #525252;"> ┘</span>
-#> <span style="color: #525252;">┌ </span><span style="color: #859900;">Wiktionary</span><span style="color: #525252;"> ──────────────────────────────────────────────────────────┐</span>
-#> <span style="color: #525252;">│</span> <span style="text-decoration: underline;">sicily</span> No English definition found                                   <span style="color: #525252;">│</span>
-#> <span style="color: #525252;">└────────────────────────────────────────────────────────────────────  ┘</span>
-#> <span style="color: #525252;">┌──────────────────────────────────────────────────────────────────────┐</span>
-#> <span style="color: #525252;">│</span> Sentiment: 😐<span style="color: #525252;"> (0)</span>                                                    <span style="color: #525252;">│</span> 
-#> <span style="color: #525252;">└──────────────────────────────────────────────────────────────────────┘</span>
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pkg_name_check("sicily")
+}\if{html}{\out{</div>}}
 }
 

--- a/man/pkg_search.Rd
+++ b/man/pkg_search.Rd
@@ -9,7 +9,12 @@ pkg_search(query, ...)
 \arguments{
 \item{query}{Search query string.}
 
-\item{...}{Additional arguments passed to \code{\link[pkgsearch:pkg_search]{pkgsearch::pkg_search()}}}
+\item{...}{
+  Arguments passed on to \code{\link[pkgsearch:pkg_search]{pkgsearch::pkg_search}}
+  \describe{
+    \item{\code{from}}{Where to start listing the results, for pagination.}
+    \item{\code{size}}{The number of results to list.}
+  }}
 }
 \value{
 A data frame, that is also a \code{pak_search_result} object
@@ -26,69 +31,13 @@ etc.
 
 Simple search
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pkg_search("survival")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                                                         
-#> 1 survival 3.4.0 -- by Terry M Therneau, 4 months ago                   
-#>   Survival Analysis                                                     
-#>                                                                         
-#> 2 survminer 0.4.9 -- by Alboukadel Kassambara, 2 years ago              
-#>   Drawing Survival Curves using 'ggplot2'                               
-#>                                                                         
-#> 3 flexsurv 2.2 -- by Christopher Jackson, 6 months ago                  
-#>   Flexible Parametric Survival and Multi-State Models                   
-#>                                                                         
-#> 4 muhaz 1.2.6.4 -- by David Winsemius, 2 years ago                      
-#>   Hazard Function Estimation in Survival Analysis                       
-#>                                                                         
-#> 5 pec 2022.5.4 -- by Thomas A. Gerds, 8 months ago                      
-#>   Prediction Error Curves for Risk Prediction Models in Survival Analysi
-#> s                                                                       
-#>                                                                         
-#> 6 randomForestSRC 3.1.1 -- by Udaya B. Kogalur, 5 months ago            
-#>   Fast Unified Random Forests for Survival, Regression, and Classificati
-#> on (RF-SRC)                                                             
-#>                                                                         
-#> 7 relsurv 2.2.8 -- by Damjan Manevski, 4 months ago                     
-#>   Relative Survival                                                     
-#>                                                                         
-#> 8 survRM2 1.0.4 -- by Hajime Uno, 6 months ago                          
-#>   Comparing Restricted Mean Survival Time                               
-#>                                                                         
-#> 9 titanic 0.1.0 -- by Paul Hendricks, 7 years ago                       
-#>   Titanic Passenger Survival Data Set                                   
-#>                                                                         
-#> 10 KMsurv 0.1.5 -- by Jun Yan, 10 years ago                             
-#>   Data sets from Klein and Moeschberger (1997), Survival Analysis       
-</pre></div>
-}}
-
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pkg_search("survival")
+}\if{html}{\out{</div>}}
 
 See the underlying data frame
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{psro <- pkg_search("ropensci")
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{psro <- pkg_search("ropensci")
 psro[]
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 10 × 15</span>                                                 
-#>    score package    version    title descr…¹ date                maint…²
-#>    <span style="font-style: italic;color: #999999;">&lt;dbl&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>      <span style="font-style: italic;color: #999999;">&lt;pckg_vrs&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;dttm&gt;</span>              <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  
-#> <span style="color: #c2c2c2;"> 1</span>  538. webmockr   0.8.2      Stub… <span style="color: #999999;">"</span>Stubb… 2022-08-28 <span style="color: #999999;">19:20:02</span> Scott …
-#> <span style="color: #c2c2c2;"> 2</span>  520. RSelenium  1.7.9      R Bi… <span style="color: #999999;">"</span>Provi… 2022-09-02 <span style="color: #999999;">07:10:11</span> Ju Yeo…
-#> <span style="color: #c2c2c2;"> 3</span>  416. tracerer   2.2.2      Trac… <span style="color: #999999;">"</span>'BEAS… 2021-05-30 <span style="color: #999999;">08:40:03</span> Richèl…
-#> <span style="color: #c2c2c2;"> 4</span>  376. rfisheries 0.2        'Pro… <span style="color: #999999;">"</span>A pro… 2016-02-19 <span style="color: #999999;">08:50:03</span> Karthi…
-#> <span style="color: #c2c2c2;"> 5</span>  367. mcbette    1.15       Mode… <span style="color: #999999;">"</span>'BEAS… 2022-08-27 <span style="color: #999999;">12:30:02</span> Richèl…
-#> <span style="color: #c2c2c2;"> 6</span>  359. taxize     0.9.100    Taxo… <span style="color: #999999;">"</span>Inter… 2022-04-22 <span style="color: #999999;">07:30:02</span> Zachar…
-#> <span style="color: #c2c2c2;"> 7</span>  350. beastier   2.4.11     Call… <span style="color: #999999;">"</span>'BEAS… 2022-08-11 <span style="color: #999999;">13:40:04</span> Richèl…
-#> <span style="color: #c2c2c2;"> 8</span>  347. spocc      1.2.0      Inte… <span style="color: #999999;">"</span>A pro… 2021-01-05 <span style="color: #999999;">19:50:03</span> Scott …
-#> <span style="color: #c2c2c2;"> 9</span>  316. chromer    0.3        Inte… <span style="color: #999999;">"</span>A pro… 2022-10-27 <span style="color: #999999;">22:45:36</span> Karl W…
-#> <span style="color: #c2c2c2;">10</span>  315. visdat     0.5.3      Prel… <span style="color: #999999;">"</span>Creat… 2019-02-15 <span style="color: #999999;">14:30:03</span> Nichol…
-#> <span style="color: #999999;"># … with 8 more variables: maintainer_email &lt;chr&gt;, revdeps &lt;int&gt;,</span>       
-#> <span style="color: #999999;">#   downloads_last_month &lt;int&gt;, license &lt;chr&gt;, url &lt;chr&gt;,</span>               
-#> <span style="color: #999999;">#   bugreports &lt;chr&gt;, package_data &lt;I&lt;list&gt;&gt;, ago &lt;chr&gt;, and</span>            
-#> <span style="color: #999999;">#   abbreviated variable names ¹​description, ²​maintainer_name</span>         
-</pre></div>
-}}
+}\if{html}{\out{</div>}}
 }
 

--- a/man/pkg_status.Rd
+++ b/man/pkg_status.Rd
@@ -22,23 +22,8 @@ Display installed locations of a package
 \section{Examples}{
 
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{pkg_status("MASS")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 2 × 39</span>                                                  
-#>   library    package title version depends repos…¹ license needs…² built
-#> <span style="color: #c2c2c2;">*</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>      <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;lgl&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>
-#> <span style="color: #c2c2c2;">1</span> /Users/ga… MASS    Supp… 7.3-58… R (&gt;= … CRAN    GPL-2 … TRUE    R 4.…
-#> <span style="color: #c2c2c2;">2</span> /Library/… MASS    Supp… 7.3-58… R (&gt;= … CRAN    GPL-2 … TRUE    R 4.…
-#> <span style="color: #999999;"># … with 30 more variables: remotetype &lt;chr&gt;, remotepkgref &lt;chr&gt;,</span>       
-#> <span style="color: #999999;">#   remoteref &lt;chr&gt;, remoterepos &lt;chr&gt;, remotepkgplatform &lt;chr&gt;,</span>        
-#> <span style="color: #999999;">#   remotesha &lt;chr&gt;, imports &lt;chr&gt;, suggests &lt;chr&gt;, linkingto &lt;chr&gt;,</span>    
-#> <span style="color: #999999;">#   remotes &lt;chr&gt;, remotehost &lt;chr&gt;, remoterepo &lt;chr&gt;,</span>                  
-#> <span style="color: #999999;">#   remoteusername &lt;chr&gt;, enhances &lt;chr&gt;, biocviews &lt;chr&gt;,</span>              
-#> <span style="color: #999999;">#   remoteurl &lt;chr&gt;, remotesubdir &lt;chr&gt;, priority &lt;chr&gt;,</span>                
-#> <span style="color: #999999;">#   remoteetag &lt;chr&gt;, remotepackaged &lt;chr&gt;, md5sum &lt;chr&gt;, …</span>             
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{pkg_status("MASS")
+}\if{html}{\out{</div>}}
 }
 
 \seealso{

--- a/man/pkg_sysreqs.Rd
+++ b/man/pkg_sysreqs.Rd
@@ -9,12 +9,12 @@ pkg_sysreqs(pkg, upgrade = TRUE, dependencies = NA, sysreqs_platform = NULL)
 \arguments{
 \item{pkg}{Package names or package references. E.g.
 \itemize{
-\item \code{ggplot2}: package from CRAN, Bioconductor or a CRAN-like repository
+\item \code{ggplot2} or \code{cran::ggplot2}: package from CRAN, Bioconductor or a CRAN-like repository
 in general,
-\item \code{tidyverse/ggplot2}: package from GitHub,
-\item \code{tidyverse/ggplot2@v3.4.0}: package from GitHub tag or branch,
-\item \verb{https://examples.com/.../ggplot2_3.3.6.tar.gz}: package from URL,
-\item \code{.}: package in the current working directory.
+\item \code{tidyverse/ggplot2} or \code{github::tidyverse/ggplot2}: package from GitHub,
+\item \code{tidyverse/ggplot2@v3.4.0} or \code{github::tidyverse/ggplot2@v3.4.0}: package from GitHub tag or branch,
+\item \verb{url::https://examples.com/.../ggplot2_3.3.6.tar.gz}: package from URL,
+\item \code{.} or \code{local::.}: package in the current working directory.
 }
 
 See "\link{Package sources}" for more details.}

--- a/man/repo_add.Rd
+++ b/man/repo_add.Rd
@@ -94,49 +94,18 @@ will trigger an error.
 \section{Exaples}{
 
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{repo_add(PPMdplyr100 = "PPM@dplyr-1.0.0")
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{repo_add(PPMdplyr100 = "PPM@dplyr-1.0.0")
 repo_get()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 7 × 5</span>                                                   
-#>   name          url                         type  r_version bioc_version
-#> <span style="color: #c2c2c2;">*</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>         <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>                       <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>     <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>       
-#> <span style="color: #c2c2c2;">1</span> CRAN          https://cloud.r-project.org cran  *         <span style="color: #DC322F;">NA</span>          
-#> <span style="color: #c2c2c2;">2</span> PPMdplyr100   https://packagemanager.pos… cran… *         <span style="color: #DC322F;">NA</span>          
-#> <span style="color: #c2c2c2;">3</span> BioCsoft      https://bioconductor.org/p… bioc  4.3.1     3.17        
-#> <span style="color: #c2c2c2;">4</span> BioCann       https://bioconductor.org/p… bioc  4.3.1     3.17        
-#> <span style="color: #c2c2c2;">5</span> BioCexp       https://bioconductor.org/p… bioc  4.3.1     3.17        
-#> <span style="color: #c2c2c2;">6</span> BioCworkflows https://bioconductor.org/p… bioc  4.3.1     3.17        
-#> <span style="color: #c2c2c2;">7</span> BioCbooks     https://bioconductor.org/p… bioc  4.3.1     3.17        
-</pre></div>
-}}
+}\if{html}{\out{</div>}}
 
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{repo_resolve("PPM@2020-01-21")
+}\if{html}{\out{</div>}}
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{repo_resolve("PPM@2020-01-21")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                       CRAN                              
-#> "https://packagemanager.posit.co/cran/245"                              
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{repo_resolve("PPM@dplyr-1.0.0")
+}\if{html}{\out{</div>}}
 
-
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{repo_resolve("PPM@dplyr-1.0.0")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                       CRAN                              
-#> "https://packagemanager.posit.co/cran/289"                              
-</pre></div>
-}}
-
-
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{repo_resolve("PPM@R-4.0.0")
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#>                                       CRAN                              
-#> "https://packagemanager.posit.co/cran/276"                              
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{repo_resolve("PPM@R-4.0.0")
+}\if{html}{\out{</div>}}
 }
 
 \seealso{

--- a/man/repo_get.Rd
+++ b/man/repo_get.Rd
@@ -27,20 +27,8 @@ Bioconductor repositories. See the \code{cran_mirror} and \code{bioc} arguments.
 \section{Examples}{
 
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{repo_get()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 5 × 5</span>                                                   
-#>   name          url                                type  r_ver…¹ bioc_…²
-#> <span style="color: #c2c2c2;">*</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>         <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>                              <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  
-#> <span style="color: #c2c2c2;">1</span> CRAN          https://cloud.r-project.org        cran  *       <span style="color: #DC322F;">NA</span>     
-#> <span style="color: #c2c2c2;">2</span> BioCsoft      https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">3</span> BioCann       https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">4</span> BioCexp       https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #c2c2c2;">5</span> BioCworkflows https://bioconductor.org/packages… bioc  4.2.2   3.16   
-#> <span style="color: #999999;"># … with abbreviated variable names ¹​r_version, ²​bioc_version</span>         
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{repo_get()
+}\if{html}{\out{</div>}}
 }
 
 \seealso{

--- a/man/repo_status.Rd
+++ b/man/repo_status.Rd
@@ -67,69 +67,17 @@ summary of the data, and it returns its result invisibly.
 \section{Examples}{
 
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{repo_status()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 10 × 10</span>                                                 
-#>    name     url   type  bioc_…¹ platf…² path  r_ver…³ ok     ping error 
-#>    <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>    <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;lgl&gt;</span> <span style="font-style: italic;color: #999999;">&lt;dbl&gt;</span> <span style="font-style: italic;color: #999999;">&lt;list&gt;</span>
-#> <span style="color: #c2c2c2;"> 1</span> CRAN     http… cran  <span style="color: #DC322F;">NA</span>      source  src/… 4.2     TRUE  0.269 <span style="color: #999999;">&lt;NULL&gt;</span>
-#> <span style="color: #c2c2c2;"> 2</span> CRAN     http… cran  <span style="color: #DC322F;">NA</span>      aarch6… bin/… 4.2     TRUE  0.265 <span style="color: #999999;">&lt;NULL&gt;</span>
-#> <span style="color: #c2c2c2;"> 3</span> BioCsoft http… bioc  3.16    source  src/… 4.2     TRUE  0.264 <span style="color: #999999;">&lt;NULL&gt;</span>
-#> <span style="color: #c2c2c2;"> 4</span> BioCsoft http… bioc  3.16    aarch6… bin/… 4.2     TRUE  0.271 <span style="color: #999999;">&lt;NULL&gt;</span>
-#> <span style="color: #c2c2c2;"> 5</span> BioCann  http… bioc  3.16    source  src/… 4.2     TRUE  0.383 <span style="color: #999999;">&lt;NULL&gt;</span>
-#> <span style="color: #c2c2c2;"> 6</span> BioCann  http… bioc  3.16    aarch6… bin/… 4.2     TRUE  0.392 <span style="color: #999999;">&lt;NULL&gt;</span>
-#> <span style="color: #c2c2c2;"> 7</span> BioCexp  http… bioc  3.16    source  src/… 4.2     TRUE  0.507 <span style="color: #999999;">&lt;NULL&gt;</span>
-#> <span style="color: #c2c2c2;"> 8</span> BioCexp  http… bioc  3.16    aarch6… bin/… 4.2     TRUE  0.739 <span style="color: #999999;">&lt;NULL&gt;</span>
-#> <span style="color: #c2c2c2;"> 9</span> BioCwor… http… bioc  3.16    source  src/… 4.2     TRUE  0.505 <span style="color: #999999;">&lt;NULL&gt;</span>
-#> <span style="color: #c2c2c2;">10</span> BioCwor… http… bioc  3.16    aarch6… bin/… 4.2     TRUE  0.766 <span style="color: #999999;">&lt;NULL&gt;</span>
-#> <span style="color: #999999;"># … with abbreviated variable names ¹​bioc_version, ²​platform,</span>         
-#> <span style="color: #999999;">#   ³​r_version</span>                                                         
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{repo_status()
+}\if{html}{\out{</div>}}
 
-
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{repo_status(
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{repo_status(
   platforms = c("windows", "macos"),
   r_version = c("4.0", "4.1")
 )
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> <span style="color: #999999;"># A data frame: 15 × 10</span>                                                 
-#>    name          url    type  bioc_…¹ platf…² r_ver…³ path  ok      ping
-#>    <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>         <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>  <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span>   <span style="font-style: italic;color: #999999;">&lt;chr&gt;</span> <span style="font-style: italic;color: #999999;">&lt;lgl&gt;</span>  <span style="font-style: italic;color: #999999;">&lt;dbl&gt;</span>
-#> <span style="color: #c2c2c2;"> 1</span> CRAN          https… cran  <span style="color: #DC322F;">NA</span>      i386+x… 4.0     bin/… TRUE   0.198
-#> <span style="color: #c2c2c2;"> 2</span> CRAN          https… cran  <span style="color: #DC322F;">NA</span>      i386+x… 4.1     bin/… TRUE   0.197
-#> <span style="color: #c2c2c2;"> 3</span> CRAN          https… cran  <span style="color: #DC322F;">NA</span>      aarch6… 4.1     bin/… TRUE   0.197
-#> <span style="color: #c2c2c2;"> 4</span> BioCsoft      https… bioc  3.12    i386+x… 4.0     bin/… TRUE   0.988
-#> <span style="color: #c2c2c2;"> 5</span> BioCann       https… bioc  3.12    i386+x… 4.0     bin/… TRUE   1.03 
-#> <span style="color: #c2c2c2;"> 6</span> BioCexp       https… bioc  3.12    i386+x… 4.0     bin/… TRUE   1.25 
-#> <span style="color: #c2c2c2;"> 7</span> BioCworkflows https… bioc  3.12    i386+x… 4.0     bin/… TRUE   1.47 
-#> <span style="color: #c2c2c2;"> 8</span> BioCsoft      https… bioc  3.14    i386+x… 4.1     bin/… TRUE   1.48 
-#> <span style="color: #c2c2c2;"> 9</span> BioCsoft      https… bioc  3.14    aarch6… 4.1     bin/… FALSE <span style="color: #DC322F;">NA</span>    
-#> <span style="color: #c2c2c2;">10</span> BioCann       https… bioc  3.14    i386+x… 4.1     bin/… TRUE   1.45 
-#> <span style="color: #c2c2c2;">11</span> BioCann       https… bioc  3.14    aarch6… 4.1     bin/… FALSE <span style="color: #DC322F;">NA</span>    
-#> <span style="color: #c2c2c2;">12</span> BioCexp       https… bioc  3.14    i386+x… 4.1     bin/… TRUE   1.72 
-#> <span style="color: #c2c2c2;">13</span> BioCexp       https… bioc  3.14    aarch6… 4.1     bin/… FALSE <span style="color: #DC322F;">NA</span>    
-#> <span style="color: #c2c2c2;">14</span> BioCworkflows https… bioc  3.14    i386+x… 4.1     bin/… TRUE   1.71 
-#> <span style="color: #c2c2c2;">15</span> BioCworkflows https… bioc  3.14    aarch6… 4.1     bin/… FALSE <span style="color: #DC322F;">NA</span>    
-#> <span style="color: #999999;"># … with 1 more variable: error &lt;list&gt;, and abbreviated variable names</span>  
-#> <span style="color: #999999;">#   ¹​bioc_version, ²​platform, ³​r_version</span>                             
-</pre></div>
-}}
+}\if{html}{\out{</div>}}
 
-
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{repo_ping()
-}\if{html}{\out{</div>}}\if{html}{\out{
-<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
-#> Repository summary:                   source aarch64-apple-darwin20<span style="color: #2AA198;">          </span>
-#> CRAN          @ cloud.r-project.org   <span style="color: #859900;">  ✔   </span> <span style="color: #859900;">          ✔           </span><span style="color: #2AA198;">   (194ms)</span>
-#> BioCsoft      @ bioconductor.org      <span style="color: #859900;">  ✔   </span> <span style="color: #859900;">          ✔           </span><span style="color: #2AA198;">   (352ms)</span>
-#> BioCann       @ bioconductor.org      <span style="color: #859900;">  ✔   </span> <span style="color: #859900;">          ✔           </span><span style="color: #2AA198;">   (511ms)</span>
-#> BioCexp       @ bioconductor.org      <span style="color: #859900;">  ✔   </span> <span style="color: #859900;">          ✔           </span><span style="color: #2AA198;">   (675ms)</span>
-#> BioCworkflows @ bioconductor.org      <span style="color: #859900;">  ✔   </span> <span style="color: #859900;">          ✔           </span><span style="color: #2AA198;">   (698ms)</span>
-</pre></div>
-}}
+\if{html}{\out{<div class="sourceCode asciicast">}}\preformatted{repo_ping()
+}\if{html}{\out{</div>}}
 }
 
 \seealso{


### PR DESCRIPTION
`url::` seems to be required for URLs, this also seems to be a lightweight way to introduce the source qualifier.

I'm not sure I can successfully run `devtools::document()`, submitting as is.