### PR TITLE
Refining system requirements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: pak
-Version: 0.5.1.9000
+Version: 0.5.1.9009
 Title: Another Approach to Package Installation
 Description: The goal of 'pak' is to make package installation faster and
     more reliable. In particular, it performs all HTTP operations in parallel,

--- a/R/system-requirements.R
+++ b/R/system-requirements.R
@@ -56,12 +56,17 @@ pkg_system_requirements <- function(package, os = NULL, os_release = NULL, execu
   if (execute) invisible(res) else res
 }
 
+
+
+
 system_requirements_internal <- function(os, os_release, root, package, execute, sudo, echo) {
   if (is.null(os) || is.null(os_release)) {
     d <- distro::distro()
     os <- os %||% d$id
     os_release <- os_release %||% d$short_version
   }
+  
+  
 
   os_versions <- supported_os_versions()
 
@@ -71,22 +76,72 @@ system_requirements_internal <- function(os, os_release, root, package, execute,
 
   rspm <- Sys.getenv("RSPM_ROOT", DEFAULT_RSPM)
   rspm_repo_id <- Sys.getenv("RSPM_REPO_ID", DEFAULT_RSPM_REPO_ID)
-  rspm_repo_url <- sprintf("%s/__api__/repos/%s", rspm, rspm_repo_id)
+  rspm_repo_url <- sprintf("%s/__api__/repos", rspm)
 
 
   if (!is.null(package)) {
-    req_url <- sprintf(
-      "%s/sysreqs?all=false&pkgname=%s&distribution=%s&release=%s",
-      rspm_repo_url,
-      paste(package, collapse = "&pkgname="),
-      os,
-      os_release
-    )
-    res <- curl::curl_fetch_memory(req_url)
-    data <- jsonlite::fromJSON(rawToChar(res$content), simplifyVector = FALSE)
-    if (!is.null(data$error)) {
-      stop(data$error)
+    
+    filter_repos <- function(rspm_repo_url) {
+      res <- curl::curl_fetch_memory(rspm_repo_url)
+      data <-
+        jsonlite::fromJSON(rawToChar(res$content), simplifyVector = FALSE)
+      repos <- c()
+      for (i in 1:length(data)) {
+        if ((data[[i]]$type == "R") ||
+            (data[[i]]$type == "Bioconductor"))
+          repos = c(repos, data[[i]]$id)
+      }
+      repos
     }
+    
+    find_package_deps <- function(rspm_repo_url,package,os,os_release,repo_numbers) {
+      appendstr <- ""
+      ctr = 1
+      deps_found <- FALSE
+      if (!is.null(package)) {
+        while (!deps_found) {
+          message(sprintf(">>> %s", ctr))
+          req_url <- sprintf(
+            "%s/%s/sysreqs?all=false&pkgname=%s&distribution=%s&release=%s%s",
+            rspm_repo_url,
+            repo_numbers[ctr],
+            paste(package, collapse = "&pkgname="),
+            os,
+            os_release,
+            appendstr
+          )
+          message(sprintf("%s: %s", ctr,req_url))
+          res <- curl::curl_fetch_memory(req_url)
+          message(sprintf("A %s: %s", ctr, res$status_code))
+          if (res$status_code == "404" && length(res$content) == 0) {
+            ctr = ctr + 1
+            message(sprintf("B %s: %s", ctr, res$status_code))
+          } else {
+            data <-
+              jsonlite::fromJSON(rawToChar(res$content), simplifyVector = FALSE)
+            message(sprintf("C %s: %s", ctr, data$error))
+            if (!is.null(data$error) &&
+                data$error == sprintf("Could not locate package '%s'", package)) {
+              ctr <- ctr + 1
+            }
+            appendstr <- ""
+            if (!is.null(data$error) &&
+                data$error == "Bioconductor version not provided") {
+              if (!exists("biocvers")) {
+                biocvers <- BiocManager::version()
+              }
+              appendstr = sprintf("&bioc_version=%s", biocvers)
+            }
+            if (res$status_code == "200") {
+              deps_found <- TRUE
+            }
+          }
+        }
+        data
+      }
+    }
+    
+    data<-find_package_deps(rspm_repo_url,package,os,os_release,filter_repos(rspm_repo_url))
 
     pre_install <- unique(unlist(c(data[["pre_install"]], lapply(data[["requirements"]], `[[`, c("requirements", "pre_install")))))
     install_scripts <- unique(unlist(c(data[["install_scripts"]], lapply(data[["requirements"]], `[[`, c("requirements", "install_scripts")))))


### PR DESCRIPTION
This is an early version of a PR that will enhance `pak::pkg_system_requirements()` so that it will check all `R` and `Bioconductor` type repositories on a given packagemanager (only URL of packagemanager needs to be specified) and extract system dependencies of a given set of packages. 

Previously, `pak::pkg_system_requirements()` only worked for a single repository and the list of packages had to be split before making a function call. 

In addition, the PR also automatically detects if a repository is of type `Bioconductor` and then appends `bioc_version=x.y` to the API call. 

Example: 
```
> pak::pkg_system_requirements(c("tidyverse","clustermq","flowcatchR"), os="ubuntu", os_release="20.04")
[1] "apt-get install -y  imagemagick  libmagick++-dev  gsfonts  libfreetype6-dev  libfribidi-dev  libharfbuzz-dev  libfontconfig1-dev  pandoc  libicu-dev  libjpeg-dev  libpng-dev  libtiff-dev  libzmq3-dev  zlib1g-dev  libssl-dev  make  libxml2-dev  libcurl4-openssl-dev"
> pak::pkg_system_requirements(c("tidyverse","clustermq","flowcatchR"), os="centos", os_release="7")
[1] "yum install -y epel-release"                                                                                                                                                                                                                                             
[2] "yum install -y  ImageMagick  ImageMagick-c++-devel  freetype-devel  fribidi-devel  harfbuzz-devel  fontconfig-devel  pandoc  libicu-devel  libjpeg-turbo-devel  libpng-devel  libtiff-devel  zeromq-devel  zlib-devel  openssl-devel  make  libxml2-devel  libcurl-devel"
```

Without the PR `pak` will report
```
> pak::pkg_system_requirements(c("tidyverse","clustermq","flowcatchR"), os="ubuntu", os_release="20.04")
Error: 
! error in pak subprocess
Caused by error in `asNamespace("pak")$system_requirements_internal(...)`:
! Could not locate package 'flowcatchR'
Type .Last.error to see the more details.
```
which is expected as `flowcatchR` is a Bioconductor package and as such not in the (default) CRAN repo. 

*Note*: 

- I deliberately left some verbose debug statements in. Also the code probably can be streamlined further by a more skilled R developers. Just wanted to make a start to get this functionality in in order to increase it's usability. 
- the question around Bioconductor support probably needs to be discussed in more detail as the current PR has a hard dependency on the R package `BiocManager`.