### PR TITLE
Allow multiple pkgs in pkg_status, pkg_deps, pkg_deps_tree

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -149,7 +149,7 @@ pkg_install_do_plan <- function(proposal) {
 #' ```
 
 pkg_status <- function(pkg, lib = .libPaths()) {
-  stopifnot(length(pkg == 1) && is.character(pkg))
+  stopifnot(length(pkg) > 0 && is.character(pkg))
 
   load_extra("pillar")
   remote(
@@ -208,7 +208,7 @@ pkg_remove_internal <- function(pkg, lib) {
 #' ```
 
 pkg_deps <- function(pkg, upgrade = TRUE, dependencies = NA) {
-  stopifnot(length(pkg) == 1 && is.character(pkg))
+  stopifnot(length(pkg) > 0 && is.character(pkg))
   load_extra("pillar")
   remote(
     function(...) {
@@ -257,7 +257,7 @@ pkg_deps_internal2 <- function(pkg, upgrade, dependencies) {
 #' ```
 
 pkg_deps_tree <- function(pkg, upgrade = TRUE, dependencies = NA) {
-  stopifnot(length(pkg == 1) && is.character(pkg))
+  stopifnot(length(pkg) > 0 && is.character(pkg))
   ret <- remote(
     function(...) {
       get("pkg_deps_tree_internal", asNamespace("pak"))(...)


### PR DESCRIPTION
pak previously supported a vector of packages in all of `pkg_status()`, `pkg_deps()`, `pkg_deps_tree()`, which was extremely useful for some private-package functions despite being (maybe?) unintentional due to a bug in a `stopifnot()` assertion (#333) 

I've tested out the following with this branch and they return expected output for a vector of packages:
```r
devtools::load_all()
pkgs <- c("nflreadr", "memoise")
```
pkg_status seems to return the rows in question
```r
pkg_status(pkgs)
#> # A data frame: 2 × 36
#>   library         package version title depends imports license needscompilation
#> * <chr>           <chr>   <chr>   <chr> <chr>   <chr>   <chr>   <lgl>           
#> 1 C:/Users/Tan/A… memoise 2.0.1   'Mem… <NA>    "rlang… MIT + … FALSE           
#> 2 C:/Users/Tan/A… nflrea… 1.3.2.… Down… R (>= … "cache… MIT + … FALSE           
#> # ℹ 28 more variables: repository <chr>, built <chr>, remotetype <chr>,
#> #   remotepkgref <chr>, remoteref <chr>, remoterepos <chr>, {...}
```
pkg_deps also returns all dependencies
```r
pkg_deps(pkgs)
#> ℹ Loading metadata database✔ Loading metadata database ... done
#> # A data frame: 10 × 32
#>    ref    type  direct directpkg status package version license needscompilation
#>    <chr>  <chr> <lgl>  <lgl>     <chr>  <chr>   <chr>   <chr>   <lgl>           
#>  1 cachem stan… FALSE  FALSE     OK     cachem  1.0.8   MIT + … TRUE            
#>  2 cli    stan… FALSE  FALSE     OK     cli     3.6.1   MIT + … TRUE            
#> # ℹ 23 more variables: priority <chr>, md5sum <chr>, sha256 <chr>, {...}
```
pkg_deps_tree returns two separate trees
```r
pkg_deps_tree(pkgs)
#> memoise 2.0.1 [new][dl] (50.28 kB)
#> ├─rlang 1.1.1 [new][cmp][dl] (1.57 MB)
#> └─cachem 1.0.8 [new][cmp][dl] (72.49 kB)
#>   ├─rlang
#>   └─fastmap 1.1.1 [new][cmp][dl] (129.72 kB)
#> 
#> nflreadr 1.3.2 [new][dl] (1.04 MB)
#> ├─cachem 1.0.8 [new][cmp][dl] (72.49 kB)
#> │ ├─rlang 1.1.1 [new][cmp][dl] (1.57 MB)
#> │ └─fastmap 1.1.1 [new][cmp][dl] (129.72 kB)
#> ├─cli 3.6.1 [new][cmp][dl] (1.33 MB)
#> ├─curl 5.0.1 [new][cmp][dl] (2.66 MB)
#> ├─data.table 1.14.8 [new][cmp][dl] (2.28 MB)
#> ├─glue 1.6.2 [new][cmp][dl] (161.80 kB)
#> ├─memoise 2.0.1 [new][dl] (50.28 kB)
#> │ ├─rlang
#> │ └─cachem
#> ├─rappdirs 0.3.3 [new][cmp][dl] (51.27 kB)
#> └─rlang
#> 
#> Key:  [new] new | [dl] download | [cmp] compile
```

I also briefly checked the errors thrown here. 
```r
pkg_err <- c("nflreadr", "memose")
pkg_status(pkg_err)
#> # A data frame: 1 × 36
#>   library         package version title depends imports license needscompilation
#> * <chr>           <chr>   <chr>   <chr> <chr>   <chr>   <chr>   <lgl>           
#> 1 C:/Users/Tan/A… nflrea… 1.3.2.… Down… R (>= … "cache… MIT + … FALSE           
#> # ℹ 28 more variables: repository <chr>, built <chr>, remotetype <chr>, {...}
pkg_deps(pkg_err)
#> ℹ Loading metadata database✔ Loading metadata database ... done
#> Error: ! error in pak subprocess
#> Caused by error: 
#> ! Could not solve package dependencies:
#> * nflreadr: dependency conflict
#> * memose: Can't find package called memose.
pkg_deps_tree(pkg_err)
#> Error: ! error in pak subprocess
#> Caused by error: 
#> ! Could not solve package dependencies:
#> * nflreadr: dependency conflict
#> * memose: Can't find package called memose.
```
The latter two errors look fine to me, I think pkg_status() should probably check to make sure the packages requested are actually returned and maybe stop/warn if missing? This isn't a current feature even for one package as the arg:
```r
R> pak::pkg_status("memose")
# A data frame: 0 × 36
# ℹ 36 variables: library <chr>, package <chr>, version <chr>, title <chr>, depends <chr>, imports <chr>, {...}
```