### PR TITLE
Add missing space in download info message

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -71,7 +71,7 @@ print_install_summary <- function(x) {
     bytes <- prettyunits::pretty_bytes(dlbytes)
     paste0(
       ", dld {downloaded}",
-      if (!is.na(bytes) && bytes != 0) " ({bytes})"
+      if (!is.na(bytes) && bytes != 0) " ({bytes}) "
     )
   } else {
     ""


### PR DESCRIPTION
Took a guess, but thought this would add the space missing here.
```r
# now
 Downloaded 1 package (260.26 kB)in 1.5s    
# hopefully with this PR
 Downloaded 1 package (260.26 kB) in 1.5s    
```
Lmk if that is not the correct place.