### PR TITLE
Enumerate additional arguments in pkg_search

### DIFF
--- a/R/search.R
+++ b/R/search.R
@@ -7,7 +7,7 @@
 #' etc.
 #'
 #' @param query Search query string.
-#' @param ... Additional arguments passed to [pkgsearch::pkg_search()]
+#' @inheritDotParams pkgsearch::pkg_search size from
 #' @return A data frame, that is also a `pak_search_result` object
 #' with a custom print method. To see the underlying table, you
 #' can use `[]` to drop the extra classes. See examples below.


### PR DESCRIPTION
I don't want to commit the redoc, but somehow, the fact that pkgsearch is not needed for that function can make it useful to enumerate the two additional args from pkgsearch..



```r
\item{...}{
Arguments passed on to \code{\link[pkgsearch:pkg_search]{pkgsearch::pkg_search}}
 \describe{
\item{\code{from}}{Where to start listing the results, for pagination.}
 \item{\code{size}}{The number of results to list.}
}}
```