### PR TITLE
Fix typo in README

### DIFF
--- a/man/chunks/FAQ.Rmd
+++ b/man/chunks/FAQ.Rmd
@@ -32,7 +32,7 @@ always chooses binaries over source packages, so if you use `pkg_install()`
 you don't need to do anything extra.
 
 The `local_install_*` functions default to `upgrade = TRUE`, as does `pak()`
-with `pkf = NULL`, so for these you need to explicitly use `upgrade = FALSE`.
+with `pkg = NULL`, so for these you need to explicitly use `upgrade = FALSE`.
 
 ## How do I install a package from source?
 

--- a/man/faq.Rd
+++ b/man/faq.Rd
@@ -79,7 +79,7 @@ always chooses binaries over source packages, so if you use \code{pkg_install()}
 you don't need to do anything extra.
 
 The \verb{local_install_*} functions default to \code{upgrade = TRUE}, as does \code{pak()}
-with \code{pkf = NULL}, so for these you need to explicitly use \code{upgrade = FALSE}.
+with \code{pkg = NULL}, so for these you need to explicitly use \code{upgrade = FALSE}.
 }
 
 \subsection{How do I install a package from source?}{


### PR DESCRIPTION
Not sure why this typo no longer appears in `README.md` .