### PR TITLE
Update embed-ca-certs.R

### DIFF
--- a/R/embed-ca-certs.R
+++ b/R/embed-ca-certs.R
@@ -1,5 +1,37 @@
 
 embed_ca_certs <- function() {
     certfile <- file.path(system.file(package = "pak"), "curl-ca-bundle.crt")
-    utils::download.file("https://curl.se/ca/cacert.pem", certfile)
+    # utils::download.file("https://curl.se/ca/cacert.pem", certfile  )
+    download_file("https://curl.se/ca/cacert.pem",   certfile , method = NULL    )
+}
+get_env_safe <-function(key  , default = NULL ){
+ try({
+    default = Sys.getenv(key )
+  })
+  default
+}
+
+download_file<-function(url,
+                        destfile ,
+                        method = NULL  ,
+                        quiet = FALSE,
+                        mode = "w",
+                        cacheOK = TRUE,
+                        extra = getOption("download.file.extra"),
+                        headers = NULL,
+                        ...){
+
+  if(is.null(method)){
+    method <- get_env_safe( "pak_ENV_download_file_method" , default = "libcurl" )
+  }
+    
+  utils::download.file(url ,
+                       destfile ,
+                       method = method  , 
+                       quiet = quiet ,
+                       mode = mode ,
+                       cacheOK = cacheOK ,
+                       extra = extra, 
+                       headers  =headers
+                       , ...  )
 }


### PR DESCRIPTION
to let user pass some arguments (`method` argument in this case) to utils::download.file method whenever it needs to be called.  method such as  "wininet" / "libcurl" . 
In this PR I suggested an override method download_file which checks environment variable `pak_ENV_download_file_method` if it is set