### PR TITLE
Small suggestion - update FAQ about using pak with renv

### DIFF
--- a/man/chunks/FAQ.Rmd
+++ b/man/chunks/FAQ.Rmd
@@ -76,5 +76,6 @@ Note that you can only ignore _optional_ dependencies, i.e. packages in
 
 ## How can I use pak with renv?
 
-You cannot currently, but keep on eye on this issue:
-https://github.com/r-lib/pak/issues/343
+Since version 1.0.0 renv has official support for using pak. This needs to be
+enabled with the `renv.config.pak.enabled` option or the `RENV_CONFIG_PAK_ENABLED` environment variable set to `TRUE`. For more information see the renv
+[documentation](https://rstudio.github.io/renv/reference/config.html?q=pak#renv-config-pak-enabled).

--- a/man/faq.Rd
+++ b/man/faq.Rd
@@ -157,8 +157,9 @@ Note that you can only ignore \emph{optional} dependencies, i.e. packages in
 \section{Others}{
 \subsection{How can I use pak with renv?}{
 
-You cannot currently, but keep on eye on this issue:
-https://github.com/r-lib/pak/issues/343
+Since version 1.0.0 renv has official support for using pak. This needs to be
+enabled with the \code{renv.config.pak.enabled} option or the \code{RENV_CONFIG_PAK_ENABLED} environment variable set to \code{TRUE}. For more information see the renv
+\href{https://rstudio.github.io/renv/reference/config.html?q=pak#renv-config-pak-enabled}{documentation}.
 }
 }
 


### PR DESCRIPTION
I noticed that the FAQ about using pak in renv is out of date (as you know it's been possible for quite a while)

<https://pak.r-lib.org/reference/faq.html#how-can-i-use-pak-with-renv->

(Nb. For the second commit here, when I clicked *Document* in the RStudio Build pane in addition to faq.Rd alot of other files were amended - so I just selected the changes in that for this PR.)
