### PR TITLE
remove debian from supported version

### DIFF
--- a/R/system-requirements.R
+++ b/R/system-requirements.R
@@ -37,8 +37,8 @@ DEFAULT_RSPM <-  "https://packagemanager.rstudio.com"
 #'
 #' @inheritParams local_install
 #' @param os,os_release The operating system and operating system release
-#'   version, e.g. "ubuntu", "debian", "centos", "redhat". See
-#'   <https://github.com/rstudio/r-system-requirements#operating-systems> for
+#'   version, e.g. "ubuntu",  "centos", "redhat". See
+#'   `supported_os_versions()` for
 #'   all full list of supported operating systems.
 #'
 #'   If `NULL`, the default, these will be looked up.


### PR DESCRIPTION
Hello,
I know that the function is deprecated, but the documentation indicated that Debian was supported when it isn't.