### PR TITLE
List known platforms in `pkg_sysreqs()` documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -87,5 +87,5 @@ Config/Needs/deploy:
     processx
 Config/testthat/edition: 3
 Encoding: UTF-8
-RoxygenNote: 7.2.3.9000
+RoxygenNote: 7.3.2
 Biarch: true

--- a/R/sysreqs.R
+++ b/R/sysreqs.R
@@ -206,5 +206,5 @@ print.pak_sysreqs <- function(x, ...) {
 
 
 platforms <- function() {
-  paste0('\\code{"', sysreqs_platforms()$distribution, '"}', collapse = ", ")
+  paste0('\\code{"', sort(sysreqs_platforms()$distribution), '"}', collapse = ", ")
 }

--- a/R/sysreqs.R
+++ b/R/sysreqs.R
@@ -68,10 +68,16 @@ sysreqs_fix_installed <- function(packages = NULL,
 #' Calculate system requirements of one of more packages
 #'
 #' @inheritParams pkg_install
-#' @param sysreqs_platform System requirements platform. If `NULL`, then the
-#'   `sysreqs_platform` \eval{man_config_link("configuration option")}
-#'   is used, which defaults to the current platform. Set this option if
-#'   \eval{.packageName} does not detect your platform correctly.
+#' @param sysreqs_platform System requirements platform. 
+#' 
+#'   If `NULL`, then the `sysreqs_platform` 
+#'   \eval{man_config_link("configuration option")} is used, which defaults to 
+#'   the current platform. 
+#' 
+#'   Set this option if to one of \eval{platforms()} if \eval{.packageName} 
+#'   fails to correctly detect your platform or if you want to see the system 
+#'   requirements for a different platform.
+#'   
 #' @return List with entries:
 #'   * `os`: character string. Operating system.
 #'   * `distribution`: character string. Linux distribution, `NA` if the
@@ -196,4 +202,9 @@ print.pak_sysreqs <- function(x, ...) {
 `[.pak_sysreqs` <- function (x, i, j, drop = FALSE) {
   class(x) <- setdiff(class(x), "pak_sysreqs")
   NextMethod("[")
+}
+
+
+platforms <- function() {
+  paste0('\\code{"', sysreqs_platforms()$distribution, '"}', collapse = ", ")
 }

--- a/man/pkg_sysreqs.Rd
+++ b/man/pkg_sysreqs.Rd
@@ -41,10 +41,15 @@ See \link{Package dependency types} for other possible values and more
 information about package dependencies.
 }}
 
-\item{sysreqs_platform}{System requirements platform. If \code{NULL}, then the
-\code{sysreqs_platform} \eval{man_config_link("configuration option")}
-is used, which defaults to the current platform. Set this option if
-\eval{.packageName} does not detect your platform correctly.}
+\item{sysreqs_platform}{System requirements platform.
+
+If \code{NULL}, then the \code{sysreqs_platform}
+\eval{man_config_link("configuration option")} is used, which defaults to
+the current platform.
+
+Set this option if to one of \eval{platforms()} if \eval{.packageName}
+fails to correctly detect your platform or if you want to see the system
+requirements for a different platform.}
 }
 \value{
 List with entries:
@@ -82,8 +87,8 @@ Calculate system requirements of one of more packages
 Other package functions: 
 \code{\link{lib_status}()},
 \code{\link{pak}()},
-\code{\link{pkg_deps_tree}()},
 \code{\link{pkg_deps}()},
+\code{\link{pkg_deps_tree}()},
 \code{\link{pkg_download}()},
 \code{\link{pkg_install}()},
 \code{\link{pkg_remove}()},


### PR DESCRIPTION
This is the second time I've had to figure this out in order to generate a working example on my laptop, so I figured I'd actually document it. I couldn't get the documentation to build correctly and I'm not sure what style you use for these documentation helper functions, so you'll need to do a little work to finish it off.