### PR TITLE
Add support for Alpine Linux

### DIFF
--- a/R/system-requirements.R
+++ b/R/system-requirements.R
@@ -198,7 +198,8 @@ supported_os_versions <- function() {
     "centos" = c("6", "7", "8"),
     "redhat" = c("6", "7", "8"),
     "opensuse" = c("42.3", "15.0"),
-    "sle" = c("12.3", "15.0")
+    "sle" = c("12.3", "15.0"),
+    "alpine" = c("")
     #"windows" = c("")
   )
 }

--- a/src/library/pkgdepends/R/sysreqs2.R
+++ b/src/library/pkgdepends/R/sysreqs2.R
@@ -21,6 +21,7 @@ sysreqs2_cmds <- utils::read.table(
    'Fedora Linux'             linux   fedora       *         NA                  'dnf install -y'                    rpm
    'openSUSE Linux'           linux   opensuse     *         NA                  'zypper --non-interactive install'  rpm
    'SUSE Linux Enterprise'    linux   sle          *         NA                  'zypper --non-interactive install'  rpm
+   'Alpine Linux'             linux   alpine       *         NA                  'apk add --no-cache'                apk
 "))
 
 find_sysreqs_platform <- function(sysreqs_platform = NULL) {

--- a/src/library/pkgdepends/R/system-packages.R
+++ b/src/library/pkgdepends/R/system-packages.R
@@ -56,7 +56,7 @@ parse_dpkg_query_output <- function(lines) {
   provides <- lapply(provides, sub, pattern = "[ ].*$", replacement = "")
   provides <- lapply(provides, function(x) x[x != ""])
   # sorted by default
-  data.frame(
+  data_frame(
     status = status,
     package = package,
     version = version,

--- a/src/library/pkgdepends/inst/sysreqs/rules/apparmor.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/apparmor.json
@@ -26,6 +26,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["libapparmor-dev", "libapparmor"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/atk.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/atk.json
@@ -47,6 +47,15 @@
           "distribution": "sle"
         }
       ]
-    }
+    },
+    {
+      "packages": ["atk-dev", "atkmm-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
+    },
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/automake.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/automake.json
@@ -45,6 +45,10 @@
         {
           "os": "linux",
           "distribution": "sle"
+        },
+        {
+          "os": "linux",
+          "distribution": "alpine"
         }
       ]
     }

--- a/src/library/pkgdepends/inst/sysreqs/rules/berkeleydb.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/berkeleydb.json
@@ -47,6 +47,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["db-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/blender.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/blender.json
@@ -11,6 +11,10 @@
           {
             "os": "linux",
             "distribution": "debian"
+          },
+          {
+            "os": "linux",
+            "distribution": "alpine"
           }
         ]
       },

--- a/src/library/pkgdepends/inst/sysreqs/rules/boost.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/boost.json
@@ -1,8 +1,8 @@
 {
-    "patterns": ["\\bglib\\b"],
+    "patterns": ["\\Boost\\b"],
     "dependencies": [
       {
-        "packages": ["libglib2.0-dev"],
+        "packages": ["libboost-all-dev"],
         "constraints": [
           {
             "os": "linux",
@@ -15,8 +15,12 @@
         ]
       },
       {
-        "packages": ["glib2-devel"],
+        "packages": ["boost-devel"],
         "constraints": [
+          {
+            "os": "linux",
+            "distribution": "fedora"
+          },
           {
             "os": "linux",
             "distribution": "centos"
@@ -28,15 +32,11 @@
           {
             "os": "linux",
             "distribution": "redhat"
-          },
-          {
-            "os": "linux",
-            "distribution": "fedora"
           }
         ]
       },
       {
-        "packages": ["glib2-devel"],
+        "packages": ["boost-gnu-hpc-devel"],
         "constraints": [
           {
             "os": "linux",
@@ -49,7 +49,7 @@
         ]
       },
       {
-        "packages": ["glib-dev"],
+        "packages": ["boost-dev"],
         "constraints": [
           {
             "os": "linux",

--- a/src/library/pkgdepends/inst/sysreqs/rules/cairo.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/cairo.json
@@ -58,6 +58,15 @@
           "os": "windows"
         }
       ]
-    }
+    },
+    {
+      "packages": ["cairo-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
+    },
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/chrome.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/chrome.json
@@ -53,6 +53,15 @@
           "versions": [ "36", "37" ]
         }
       ]
+    },
+    {
+      "packages": ["chromium"],
+      "constraints": [
+        {
+          "os": "linux",
+            "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/cmake.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/cmake.json
@@ -34,6 +34,10 @@
         {
           "os": "linux",
           "distribution": "fedora"
+        },
+        {
+          "os": "linux",
+          "distribution": "alpine"
         }
       ]
     },

--- a/src/library/pkgdepends/inst/sysreqs/rules/eigen.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/eigen.json
@@ -1,8 +1,8 @@
 {
-    "patterns": ["\\bpandoc\\b"],
+    "patterns": ["\\beigen3?\\b"],
     "dependencies": [
       {
-        "packages": ["pandoc"],
+        "packages": ["libeigen3-dev"],
         "constraints": [
           {
             "os": "linux",
@@ -15,16 +15,24 @@
         ]
       },
       {
-        "packages": ["pandoc"],
+        "packages": ["eigen3-devel"],
         "constraints": [
           {
             "os": "linux",
             "distribution": "fedora"
+          },
+          {
+            "os": "linux",
+            "distribution": "opensuse"
+          },
+          {
+            "os": "linux",
+            "distribution": "sle"
           }
         ]
       },
       {
-        "packages": ["pandoc"],
+        "packages": ["eigen3-devel"],
         "pre_install": [
           {
             "command": "yum install -y epel-release"
@@ -34,41 +42,12 @@
           {
             "os": "linux",
             "distribution": "centos",
-            "versions": ["6", "7"]
+            "versions": ["7"]
           }
         ]
       },
       {
-        "packages": ["pandoc"],
-        "pre_install": [
-          { "command": "dnf install -y dnf-plugins-core" },
-          { "command": "dnf config-manager --set-enabled powertools" }
-        ],
-        "constraints": [
-          {
-            "os": "linux",
-            "distribution": "centos",
-            "versions": ["8"]
-          }
-        ]
-      },
-      {
-        "packages": ["pandoc"],
-        "pre_install": [
-          {
-            "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
-          }
-        ],
-        "constraints": [
-          {
-            "os": "linux",
-            "distribution": "redhat",
-            "versions": ["6"]
-          }
-        ]
-      },
-      {
-        "packages": ["pandoc"],
+        "packages": ["eigen3-devel"],
         "pre_install": [
           {
             "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
@@ -83,16 +62,61 @@
         ]
       },
       {
-        "packages": ["pandoc"],
+        "packages": ["eigen3-devel"],
+        "pre_install": [
+          { "command": "dnf install -y dnf-plugins-core" },
+          { "command": "dnf config-manager --set-enabled powertools" }
+        ],
         "constraints": [
           {
             "os": "linux",
-            "distribution": "opensuse"
+            "distribution": "centos",
+            "versions": ["8"]
           }
         ]
       },
       {
-        "packages": ["pandoc-cli"],
+        "packages": ["eigen3-devel"],
+        "pre_install": [
+          { "command": "subscription-manager repos --enable codeready-builder-for-rhel-8-$(arch)-rpms" }
+        ],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "redhat",
+            "versions": ["8"]
+          }
+        ]
+      },
+      {
+        "packages": ["eigen3-devel"],
+        "pre_install": [
+          { "command": "dnf install -y dnf-plugins-core" },
+          { "command": "dnf config-manager --set-enabled crb" }
+        ],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "rockylinux",
+            "versions": ["9"]
+          }
+        ]
+      },
+      {
+        "packages": ["eigen3-devel"],
+        "pre_install": [
+          { "command": "subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms" }
+        ],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "redhat",
+            "versions": ["9"]
+          }
+        ]
+      },
+      {
+        "packages": ["eigen-dev"],
         "constraints": [
           {
             "os": "linux",
@@ -102,3 +126,4 @@
       }
     ]
   }
+  

--- a/src/library/pkgdepends/inst/sysreqs/rules/exiftool.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/exiftool.json
@@ -105,6 +105,10 @@
         {
           "os": "linux",
           "distribution": "opensuse"
+        },
+        {
+          "os": "linux",
+          "distribution": "alpine"
         }
       ]
     }

--- a/src/library/pkgdepends/inst/sysreqs/rules/fftw3.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/fftw3.json
@@ -58,6 +58,15 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": ["fftw-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/fluidsynth.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/fluidsynth.json
@@ -1,8 +1,8 @@
 {
-    "patterns": ["\\bglib\\b"],
+    "patterns": ["\\bfluidsynth\\b"],
     "dependencies": [
       {
-        "packages": ["libglib2.0-dev"],
+        "packages": ["libfluidsynth-dev"],
         "constraints": [
           {
             "os": "linux",
@@ -15,7 +15,23 @@
         ]
       },
       {
-        "packages": ["glib2-devel"],
+        "packages": ["fluidsynth-devel"],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "opensuse"
+          },
+          {
+            "os": "linux",
+            "distribution": "fedora"
+          }
+        ]
+      },
+      {
+        "packages": ["fluidsynth-devel"],
+        "pre_install": [
+          { "command": "yum install -y epel-release" }
+        ],
         "constraints": [
           {
             "os": "linux",
@@ -28,28 +44,11 @@
           {
             "os": "linux",
             "distribution": "redhat"
-          },
-          {
-            "os": "linux",
-            "distribution": "fedora"
           }
         ]
       },
       {
-        "packages": ["glib2-devel"],
-        "constraints": [
-          {
-            "os": "linux",
-            "distribution": "opensuse"
-          },
-          {
-            "os": "linux",
-            "distribution": "sle"
-          }
-        ]
-      },
-      {
-        "packages": ["glib-dev"],
+        "packages": ["fluidsynth-dev"],
         "constraints": [
           {
             "os": "linux",
@@ -59,3 +58,4 @@
       }
     ]
   }
+  

--- a/src/library/pkgdepends/inst/sysreqs/rules/fontconfig.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/fontconfig.json
@@ -48,6 +48,15 @@
           "distribution": "opensuse"
         }
       ]
+    },
+    {
+      "packages": ["fontconfig-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/freetype.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/freetype.json
@@ -58,6 +58,15 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": ["freetype-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/fribidi.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/fribidi.json
@@ -38,6 +38,15 @@
           "distribution": "fedora"
         }
       ]
+    },
+    {
+      "packages": ["fribidi-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/gdal.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/gdal.json
@@ -190,6 +190,18 @@
           "versions": ["12.3"]
         }
       ]
+    },
+    {
+      "packages": [
+        "gdal-dev",
+        "gdal-tools"
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/geos.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/geos.json
@@ -144,6 +144,15 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": ["geos-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/git.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/git.json
@@ -45,6 +45,10 @@
           {
             "os": "linux",
             "distribution": "sle"
+          },
+          {
+            "os": "linux",
+            "distribution": "alpine"
           }
         ]
       }

--- a/src/library/pkgdepends/inst/sysreqs/rules/glpk.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/glpk.json
@@ -126,6 +126,17 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": [
+        "glpk-dev"
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/glu.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/glu.json
@@ -47,6 +47,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["glu-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/gmp.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/gmp.json
@@ -58,6 +58,15 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": ["gmp-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/gnumake.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/gnumake.json
@@ -11,6 +11,10 @@
         {
           "os": "linux",
           "distribution": "debian"
+        },
+        {
+          "os": "linux",
+          "distribution": "alpine"
         }
       ]
     },

--- a/src/library/pkgdepends/inst/sysreqs/rules/gpgme.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/gpgme.json
@@ -90,6 +90,15 @@
             "distribution": "sle"
           }
         ]
+      },
+      {
+        "packages": ["gpgme-dev"],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "alpine"
+          }
+        ]
       }
     ]
   }

--- a/src/library/pkgdepends/inst/sysreqs/rules/gsl.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/gsl.json
@@ -81,6 +81,15 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": ["gsl-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/gtk.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/gtk.json
@@ -47,6 +47,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["gtk+2.0-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/harfbuzz.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/harfbuzz.json
@@ -38,6 +38,15 @@
           "distribution": "fedora"
         }
       ]
+    },
+    {
+      "packages": ["harfbuzz-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/haveged.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/haveged.json
@@ -127,6 +127,15 @@
             "distribution": "sle"
           }
         ]
+      },
+      {
+        "packages": ["haveged-dev"],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "alpine"
+          }
+        ]
       }
     ]
   }

--- a/src/library/pkgdepends/inst/sysreqs/rules/hdf5.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/hdf5.json
@@ -139,6 +139,15 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": ["hdf5-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/hiredis.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/hiredis.json
@@ -108,6 +108,15 @@
           "distribution": "opensuse"
         }
       ]
+    },
+    {
+      "packages": ["hiredis-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/imagemagick.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/imagemagick.json
@@ -105,6 +105,15 @@
             "distribution": "sle"
           }
         ]
+      },
+      {
+        "packages": ["imagemagick-dev", "imagemagick-c++"],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "alpine"
+          }
+        ]
       }
     ]
   }

--- a/src/library/pkgdepends/inst/sysreqs/rules/java.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/java.json
@@ -98,6 +98,15 @@
           "versions": ["15.4"]
         }
       ]
+    },
+    {
+      "packages": ["java-jdk"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/latex.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/latex.json
@@ -32,6 +32,10 @@
         {
           "os": "linux",
           "distribution": "fedora"
+        },
+        {
+          "os": "linux",
+          "distribution": "alpine"
         }
       ]
     },

--- a/src/library/pkgdepends/inst/sysreqs/rules/leptonica.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/leptonica.json
@@ -122,6 +122,15 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": ["leptonica-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libarchive.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libarchive.json
@@ -116,6 +116,15 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": ["libarchive-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libavfilter.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libavfilter.json
@@ -122,6 +122,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["ffmpeg-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libbsd.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libbsd.json
@@ -123,6 +123,15 @@
           "distribution": "opensuse"
         }
       ]
+    },
+    {
+      "packages": ["libbsd-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libcurl.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libcurl.json
@@ -58,6 +58,15 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": ["curl-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libgit2.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libgit2.json
@@ -27,6 +27,10 @@
         {
           "os": "linux",
           "distribution": "debian"
+        },
+        {
+          "os": "linux",
+          "distribution": "alpine"
         }
       ]
     },
@@ -100,9 +104,7 @@
     },
     {
       "packages": ["libgit2-devel"],
-      "pre_install": [
-        { "command": "dnf install -y epel-release" }
-      ],
+      "pre_install": [{ "command": "dnf install -y epel-release" }],
       "constraints": [
         {
           "os": "linux",
@@ -129,7 +131,9 @@
     {
       "packages": ["libgit2-devel"],
       "pre_install": [
-        { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm" }
+        {
+          "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+        }
       ],
       "constraints": [
         {

--- a/src/library/pkgdepends/inst/sysreqs/rules/libicu.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libicu.json
@@ -85,6 +85,15 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": ["icu-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libjpeg.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libjpeg.json
@@ -58,6 +58,15 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": ["jpeg-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libjq.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libjq.json
@@ -101,6 +101,15 @@
           "distribution": "opensuse"
         }
       ]
+    },
+    {
+      "packages": ["jq-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libmagic.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libmagic.json
@@ -100,6 +100,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["file-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libmysqlclient.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libmysqlclient.json
@@ -108,6 +108,15 @@
           "versions": ["15.0", "15.2", "15.3", "15.4"]
         }
       ]
+    },
+    {
+      "packages": ["mariadb-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libpng.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libpng.json
@@ -58,6 +58,15 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": ["libpng-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libprotobuf.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libprotobuf.json
@@ -134,6 +134,15 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": ["protobuf-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/librsvg2.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/librsvg2.json
@@ -47,6 +47,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["librsvg-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libsecret.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libsecret.json
@@ -47,6 +47,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["libsecret-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libsndfile.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libsndfile.json
@@ -95,6 +95,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["libsndfile-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libsodium.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libsodium.json
@@ -123,6 +123,15 @@
           "distribution": "opensuse"
         }
       ]
+    },
+    {
+      "packages": ["libsodium-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libssh2.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libssh2.json
@@ -91,6 +91,15 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": ["libssh2-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libtiff.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libtiff.json
@@ -58,6 +58,15 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": ["tiff-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libtool.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libtool.json
@@ -1,8 +1,8 @@
 {
-    "patterns": ["\\bglib\\b"],
+    "patterns": ["\\blibtool\\b"],
     "dependencies": [
       {
-        "packages": ["libglib2.0-dev"],
+        "packages": ["libtool"],
         "constraints": [
           {
             "os": "linux",
@@ -15,7 +15,7 @@
         ]
       },
       {
-        "packages": ["glib2-devel"],
+        "packages": ["libtool"],
         "constraints": [
           {
             "os": "linux",
@@ -36,7 +36,7 @@
         ]
       },
       {
-        "packages": ["glib2-devel"],
+        "packages": ["libtool"],
         "constraints": [
           {
             "os": "linux",
@@ -49,7 +49,7 @@
         ]
       },
       {
-        "packages": ["glib-dev"],
+        "packages": ["libtool"],
         "constraints": [
           {
             "os": "linux",
@@ -59,3 +59,4 @@
       }
     ]
   }
+  

--- a/src/library/pkgdepends/inst/sysreqs/rules/libwebp.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libwebp.json
@@ -99,6 +99,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["libwebp-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/libxml2.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libxml2.json
@@ -11,6 +11,10 @@
         {
           "os": "linux",
           "distribution": "debian"
+        },
+        {
+          "os": "linux",
+          "distribution": "alpine"
         }
       ]
     },

--- a/src/library/pkgdepends/inst/sysreqs/rules/libxslt.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/libxslt.json
@@ -47,6 +47,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["libxslt-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/mongodb.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/mongodb.json
@@ -50,6 +50,15 @@
           "versions": ["42.3"]
         }
       ]
+    },
+    {
+      "packages": ["mongodb-tools"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/mpfr.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/mpfr.json
@@ -47,6 +47,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["mpfr-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/mysql.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/mysql.json
@@ -54,6 +54,10 @@
         {
           "os": "linux",
           "distribution": "fedora"
+        },
+        {
+          "os": "linux",
+          "distribution": "alpine"
         }
       ]
     },

--- a/src/library/pkgdepends/inst/sysreqs/rules/netcdf4.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/netcdf4.json
@@ -133,6 +133,15 @@
           "versions": ["12.3"]
         }
       ]
+    },
+    {
+      "packages": ["netcdf-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/odbc.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/odbc.json
@@ -70,6 +70,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["unixodbc-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/opencl.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/opencl.json
@@ -104,6 +104,15 @@
           "distribution": "opensuse"
         }
       ]
+    },
+    {
+      "packages": ["opencl-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/opencv.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/opencv.json
@@ -114,6 +114,15 @@
           "versions": ["9"]
         }
       ]
+    },
+    {
+      "packages": ["opencv-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/opengl.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/opengl.json
@@ -47,6 +47,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["mesa-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/openmpi.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/openmpi.json
@@ -64,6 +64,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["openmpi-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/openssl.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/openssl.json
@@ -58,6 +58,15 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": ["openssl-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
     ]
   }

--- a/src/library/pkgdepends/inst/sysreqs/rules/pango.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/pango.json
@@ -47,6 +47,15 @@
             "distribution": "sle"
           }
         ]
+      },
+      {
+        "packages": ["pango-dev"],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "alpine"
+          }
+        ]
       }
     ]
   }

--- a/src/library/pkgdepends/inst/sysreqs/rules/perl.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/perl.json
@@ -45,6 +45,10 @@
           {
             "os": "linux",
             "distribution": "sle"
+          },
+          {
+            "os": "linux",
+            "distribution": "alpine"
           }
         ]
       }

--- a/src/library/pkgdepends/inst/sysreqs/rules/pkg-config.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/pkg-config.json
@@ -64,6 +64,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["pkgconf"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/poppler.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/poppler.json
@@ -98,6 +98,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["poppler-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/postgresql.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/postgresql.json
@@ -11,6 +11,10 @@
         {
           "os": "linux",
           "distribution": "debian"
+        },
+        {
+          "os": "linux",
+          "distribution": "alpine"
         }
       ]
     },

--- a/src/library/pkgdepends/inst/sysreqs/rules/proj.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/proj.json
@@ -152,6 +152,15 @@
           "versions": ["12.3"]
         }
       ]
+    },
+    {
+      "packages": ["proj-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/protobuf-compiler.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/protobuf-compiler.json
@@ -59,6 +59,10 @@
         {
           "os": "linux",
           "distribution": "fedora"
+        },
+        {
+          "os": "linux",
+          "distribution": "alpine"
         }
       ]
     },

--- a/src/library/pkgdepends/inst/sysreqs/rules/python.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/python.json
@@ -11,6 +11,10 @@
           {
             "os": "linux",
             "distribution": "debian"
+          },
+          {
+            "os": "linux",
+            "distribution": "alpine"
           }
         ]
       },

--- a/src/library/pkgdepends/inst/sysreqs/rules/python3.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/python3.json
@@ -11,6 +11,10 @@
           {
             "os": "linux",
             "distribution": "debian"
+          },
+          {
+            "os": "linux",
+            "distribution": "alpine"
           }
         ]
       },

--- a/src/library/pkgdepends/inst/sysreqs/rules/redland.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/redland.json
@@ -101,6 +101,15 @@
           "os": "windows"
         }
       ]
+    },
+    {
+      "packages": ["redland-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/rust.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/rust.json
@@ -83,6 +83,10 @@
         {
           "os": "linux",
           "distribution": "opensuse"
+        },
+        {
+          "os": "linux",
+          "distribution": "alpine"
         }
       ]
     }

--- a/src/library/pkgdepends/inst/sysreqs/rules/sasl.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/sasl.json
@@ -43,6 +43,15 @@
           "distribution": "opensuse"
         }
       ]
+    },
+    {
+      "packages": ["cyrus-sasl-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/sqlite3.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/sqlite3.json
@@ -47,6 +47,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["sqlite-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/suitesparse.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/suitesparse.json
@@ -93,6 +93,15 @@
           "versions": ["9"]
         }
       ]
+    },
+    {
+      "packages": ["suitesparse-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/tcltk.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/tcltk.json
@@ -32,6 +32,10 @@
         {
           "os": "linux",
           "distribution": "fedora"
+        },
+        {
+          "os": "linux",
+          "distribution": "alpine"
         }
       ]
     },

--- a/src/library/pkgdepends/inst/sysreqs/rules/tesseract.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/tesseract.json
@@ -114,6 +114,15 @@
           "distribution": "opensuse"
         }
       ]
+    },
+    {
+      "packages": ["tesseract-ocr-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/tk.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/tk.json
@@ -48,6 +48,17 @@
           "distribution": "fedora"
         }
       ]
+    },
+    {
+      "packages": [
+        "tk-dev"
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/udunits2.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/udunits2.json
@@ -114,6 +114,15 @@
           "distribution": "rockylinux"
         }
       ]
+    },
+    {
+      "packages": ["udunits-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/wget.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/wget.json
@@ -32,6 +32,10 @@
         {
           "os": "linux",
           "distribution": "fedora"
+        },
+        {
+          "os": "linux",
+          "distribution": "alpine"
         }
       ]
     },

--- a/src/library/pkgdepends/inst/sysreqs/rules/xft.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/xft.json
@@ -47,6 +47,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["libxft-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/xz.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/xz.json
@@ -1,8 +1,8 @@
 {
-    "patterns": ["\\bglib\\b"],
+    "patterns": ["\\bxz\\b"],
     "dependencies": [
       {
-        "packages": ["libglib2.0-dev"],
+        "packages": ["xz-utils"],
         "constraints": [
           {
             "os": "linux",
@@ -15,7 +15,7 @@
         ]
       },
       {
-        "packages": ["glib2-devel"],
+        "packages": ["xz"],
         "constraints": [
           {
             "os": "linux",
@@ -31,26 +31,16 @@
           },
           {
             "os": "linux",
-            "distribution": "fedora"
-          }
-        ]
-      },
-      {
-        "packages": ["glib2-devel"],
-        "constraints": [
-          {
-            "os": "linux",
             "distribution": "opensuse"
           },
           {
             "os": "linux",
             "distribution": "sle"
-          }
-        ]
-      },
-      {
-        "packages": ["glib-dev"],
-        "constraints": [
+          },
+          {
+            "os": "linux",
+            "distribution": "fedora"
+          },
           {
             "os": "linux",
             "distribution": "alpine"

--- a/src/library/pkgdepends/inst/sysreqs/rules/zeromq.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/zeromq.json
@@ -135,6 +135,15 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": ["zeromq-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
     }
   ]
 }

--- a/src/library/pkgdepends/inst/sysreqs/rules/zlib.json
+++ b/src/library/pkgdepends/inst/sysreqs/rules/zlib.json
@@ -58,6 +58,15 @@
             "os": "windows"
           }
         ]
+      },
+      {
+        "packages": ["zlib-dev"],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "alpine"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
I've been using this for several weeks now without issues.

Happy to port this to the {pkgdepends} repo if it gets approved.

## POC

```sh
docker run --rm -it alpine sh

apk add -q R R-dev linux-headers g++
R -q -e 'install.packages("remotes", repos = "cloud.r-project.org")'
R -q -e 'remotes::install_github("pat-s/pak@alpine")'

R -q -e 'pak::pak("xml2")'

✔ Updated metadata database: 2.96 MB in 8 files.
✔ Updating metadata database ... done

→ Will install 3 packages.
→ Will download 3 CRAN packages (1.63 MB).
+ cli     3.6.3 [bld][cmp][dl] (569.77 kB)
+ rlang   1.1.4 [bld][cmp][dl] (763.76 kB)
+ xml2    1.3.6 [bld][cmp][dl] (294.71 kB) + ✖ libxml2-dev
→ Will install 1 system package:
+ libxml2-dev  - xml2
ℹ Getting 3 pkgs (1.63 MB)
✔ Got xml2 1.3.6 (source) (294.71 kB)
✔ Got cli 3.6.3 (source) (568.16 kB)
✔ Got rlang 1.1.4 (source) (767.04 kB)
ℹ Installing system requirements
ℹ Executing `sh -c apk add --no-cache libxml2-dev`
ℹ Building cli 3.6.3
ℹ Building rlang 1.1.4
✔ Built cli 3.6.3 (4.3s)
✔ Installed cli 3.6.3  (32ms)
✔ Built rlang 1.1.4 (5.8s)
✔ Installed rlang 1.1.4  (38ms)
ℹ Building xml2 1.3.6
✔ Built xml2 1.3.6 (3.1s)
✔ Installed xml2 1.3.6  (22ms)
✔ 1 pkg + 2 deps: added 3, dld 3 (1.63 MB) [13.6s]
```