### PR TITLE
`upgrade` argument reflects default value stated in docs

### DIFF
--- a/R/local.R
+++ b/R/local.R
@@ -32,7 +32,7 @@
 #' @family local package trees
 #' @export
 
-local_install <- function(root = ".", lib = .libPaths()[1], upgrade = TRUE,
+local_install <- function(root = ".", lib = .libPaths()[1], upgrade = FALSE,
                           ask = interactive(), dependencies = NA) {
 
   start <- Sys.time()


### PR DESCRIPTION
In pak 0.8.0, default `local_install()`'s `upgrade` value is not in line with what's stated in the docs which inherit from `pkg_install()` (`upgrade` is `FALSE` by default).
It's less work to just change the default but this might be a breaking change, I guess.
If it's better to add ad hoc docs for this function rather than changing its default value, this PR is just meant to highlight a little inconsistency.
Thanks!

<img width="744" alt="Screenshot 2024-12-03 at 17 52 15" src="https://github.com/user-attachments/assets/3368b030-7701-4da3-8878-7ce98166fa1b">
