### PR TITLE
Fix 2 typos in docs

### DIFF
--- a/src/library/pkgdepends/R/zzz-pkgdepends-config.R
+++ b/src/library/pkgdepends/R/zzz-pkgdepends-config.R
@@ -244,8 +244,8 @@ pkgdepends_config <- sort_by_name(list(
     default = TRUE,
     docs =
       "Whether to try to update the system requirements database from
-       GitHub. If the update fails, then the cached or the build-in
-       database if used. Defaults to TRUE."
+       GitHub. If the update fails, then the cached or the built-in
+       database is used. Defaults to `TRUE`."
   ),
 
   # -----------------------------------------------------------------------


### PR DESCRIPTION
Super tiny - I noticed some typos in a sentence on <https://pak.r-lib.org/reference/pak-config.html#pak-configuration-entries> for `sysreqs_db_update`.

![CleanShot 2024-12-16 at 11 40 17@2x](https://github.com/user-attachments/assets/6e866a84-3267-486b-a971-a84e4d4d6956)
