### PR TITLE
Avoid unlocking NULL

### DIFF
--- a/src/library/pkgdepends/R/install-binary.R
+++ b/src/library/pkgdepends/R/install-binary.R
@@ -7,7 +7,9 @@ install_extracted_binary <- function(filename, lib_cache, pkg_cache, lib,
   pkg_name <- pkg$name
 
   lockfile <- lock_cache(lib_cache, pkg_name, getOption("install.lock"))
-  on.exit(filelock::unlock(lockfile), add = TRUE)
+  if (!is.null(lockfile)) {
+    on.exit(filelock::unlock(lockfile), add = TRUE)
+  }
 
   installed_path <- file.path(lib, pkg_name)
   if (file.exists(installed_path)) {


### PR DESCRIPTION
When `options(install.lock = FALSE)` is set in `.Rprofile`, an error will be thrown when a package is successfully installed:

```
Error:                                           
! error in pak subprocess
Caused by error in `filelock::unlock(lockfile)`:
! `unlock()` needs a lock object, not a file name
```

This will abort the installation of other packages.

<hr>

In `install-binary.R`, `lock_cache` will return `NULL` if `getOption("install.lock")==FALSE`, which is not a valid parameter for `filelock::unlock` :

https://github.com/r-lib/pak/blob/2c8de25e1206a8c78b867df4dc28408e72ab4c7c/src/library/pkgdepends/R/install-binary.R#L9-L10
https://github.com/r-lib/pak/blob/2c8de25e1206a8c78b867df4dc28408e72ab4c7c/src/library/pkgdepends/R/install-utils.R#L58-L67
https://github.com/r-lib/pak/blob/2c8de25e1206a8c78b867df4dc28408e72ab4c7c/src/library/filelock/R/package.R#L170-L175

This PR adds a NULL check to avoid the error.