### PR TITLE
Amend accidentally repeated word in docs

### DIFF
--- a/man/chunks/install.Rmd
+++ b/man/chunks/install.Rmd
@@ -67,7 +67,7 @@ install.packages("pak", repos = sprintf(
 
 We have three types of binaries available:
 
-* `stable` corresponds to the latest CRAN release of CRAN.
+* `stable` corresponds to the latest CRAN release of pak.
 * `rc` is a release candidate build, and it is available about 1-2 weeks
   before a release. Otherwise it is the same as the `stable` build.
 * `devel` has builds from the development tree. Before release it might be

--- a/man/install.Rd
+++ b/man/install.Rd
@@ -74,7 +74,7 @@ We have nightly binary builds, for the same systems as the table above:
 
 We have three types of binaries available:
 \itemize{
-\item \code{stable} corresponds to the latest CRAN release of CRAN.
+\item \code{stable} corresponds to the latest CRAN release of pak.
 \item \code{rc} is a release candidate build, and it is available about 1-2 weeks
 before a release. Otherwise it is the same as the \code{stable} build.
 \item \code{devel} has builds from the development tree. Before release it might be


### PR DESCRIPTION
A tiny amend of _CRAN release of CRAN_ to _CRAN release of pak_.