### PR TITLE
Clarify System Requirements Detection

### DIFF
--- a/R/sysreqs.R
+++ b/R/sysreqs.R
@@ -42,13 +42,55 @@ sysreqs_db_list <- function(sysreqs_platform = NULL) {
 
 sysreqs_check_installed <- function(packages = NULL, library = .libPaths()[1]) {
   load_extra("pillar")
-  remote(
+
+  # Check if sysreqs support is enabled in the config
+  sysreqs_enabled <- remote(
+    function() {
+      config <- pkgdepends::current_config()
+      config$get("sysreqs")
+    }
+  )
+
+  if (!sysreqs_enabled) {
+    cli::cli_alert_info(
+      "System requirements checking is disabled in the config."
+    )
+    cli::cli_alert_info(
+      "Use {.code Sys.setenv('PKG_SYSREQS' = 'TRUE')} 
+      or {.code options(pkg.sysreqs = TRUE)}."
+    )
+
+    # Return an empty data frame with the expected structure
+    result <- data.frame(
+      system_package = character(0),
+      installed = logical(0),
+      packages = I(list()),
+      pre_install = I(list()),
+      post_install = I(list())
+    )
+    class(result) <- c("pkg_sysreqs_check_result", class(result))
+    return(invisible(pak_preformat(result)))
+  }
+
+  result <- remote(
     function(...) {
       ret <- pkgdepends::sysreqs_check_installed(...)
       asNamespace("pak")$pak_preformat(ret)
     },
     list(packages = packages, library = library)
   )
+
+  # Inform about detection method
+  if (nrow(result) > 0) {
+    cli::cli_alert_info(
+      "System packages checked via system package manager only."
+    )
+    cli::cli_alert_info(
+      "Software in non-standard locations may not be detected."
+    )
+  }
+
+  result
 }
 
 sysreqs_fix_installed <- function(packages = NULL, library = .libPaths()[1]) {

--- a/R/sysreqs.R
+++ b/R/sysreqs.R
@@ -40,10 +40,7 @@ sysreqs_db_list <- function(sysreqs_platform = NULL) {
   )
 }
 
-sysreqs_check_installed <- function(packages = NULL, library = .libPaths()[1]) {
-  load_extra("pillar")
-
-  # Check if sysreqs support is enabled in the config
+check_sysreqs_enabled <- function() {
   sysreqs_enabled <- remote(
     function() {
       config <- pkgdepends::current_config()
@@ -69,7 +66,19 @@ sysreqs_check_installed <- function(packages = NULL, library = .libPaths()[1]) {
       post_install = I(list())
     )
     class(result) <- c("pkg_sysreqs_check_result", class(result))
-    return(invisible(pak_preformat(result)))
+    return(pak_preformat(result))
+  }
+
+  return(NULL)
+}
+
+sysreqs_check_installed <- function(packages = NULL, library = .libPaths()[1]) {
+  load_extra("pillar")
+
+  # Check if sysreqs is enabled, return early if disabled
+  disabled_result <- check_sysreqs_enabled()
+  if (!is.null(disabled_result)) {
+    return(invisible(disabled_result))
   }
 
   result <- remote(
@@ -96,33 +105,10 @@ sysreqs_check_installed <- function(packages = NULL, library = .libPaths()[1]) {
 sysreqs_fix_installed <- function(packages = NULL, library = .libPaths()[1]) {
   load_extra("pillar")
 
-  # Check if sysreqs support is enabled
-  sysreqs_enabled <- remote(
-    function() {
-      config <- pkgdepends::current_config()
-      config$get("sysreqs")
-    }
-  )
-
-  if (!sysreqs_enabled) {
-    cli::cli_alert_info(
-      "System requirements checking is disabled in the config."
-    )
-    cli::cli_alert_info(
-      "Use {.code Sys.setenv('PKG_SYSREQS' = 'TRUE')}
-      or {.code options(pkg.sysreqs = TRUE)}."
-    )
-
-    # Return an empty data frame with the expected structure
-    result <- data.frame(
-      system_package = character(0),
-      installed = logical(0),
-      packages = I(list()),
-      pre_install = I(list()),
-      post_install = I(list())
-    )
-    class(result) <- c("pkg_sysreqs_check_result", class(result))
-    return(invisible(pak_preformat(result)))
+  # Check if sysreqs is enabled, return early if disabled
+  disabled_result <- check_sysreqs_enabled()
+  if (!is.null(disabled_result)) {
+    return(invisible(disabled_result))
   }
 
   invisible(remote(
@@ -133,6 +119,7 @@ sysreqs_fix_installed <- function(packages = NULL, library = .libPaths()[1]) {
     list(packages = packages, library = library)
   ))
 }
+
 
 #' Calculate system requirements of one of more packages
 #'

--- a/R/sysreqs.R
+++ b/R/sysreqs.R
@@ -180,6 +180,17 @@ format.pak_sysreqs <- function(x, ...) {
     out
   }
 
+  # Add warning message about detection limitations
+  warning_msg <- c(
+    "",
+    cli$rule(left = "System package detection", col = "yellow"),
+    paste(
+      cli$col_yellow(cli$symbol$warning),
+      "System packages are detected via the system package manager only."
+    ),
+    "Software installed in non-standard locations may not be detected."
+  )
+
   c(
     cli$rule(left = "Install scripts", right = label),
     x$pre_install,
@@ -195,7 +206,8 @@ format.pak_sysreqs <- function(x, ...) {
         " ",
         vcapply(pkgs, function(x) paste(cisort(x), collapse = ", "))
       )
-    }
+    },
+    warning_msg
   )
 }
 

--- a/R/sysreqsdocs.R
+++ b/R/sysreqsdocs.R
@@ -205,3 +205,39 @@ sysreqs_fix_installed <- sysreqs_fix_installed
 #' sysreqs_list_system_packages()[1:10,]
 
 sysreqs_list_system_packages
+
+#' System requirements detection limitations
+#'
+#' @description
+#' System requirements detection in pak only considers packages installed via the system package manager.
+#' Supported package managers include:
+#' * `apt` on Debian/Ubuntu systems
+#' * `yum`/`dnf` on RedHat/CentOS/Fedora systems
+#' * `zypper` on openSUSE/SUSE systems
+#' * `apk` on Alpine systems
+#'
+#' pak does **not** detect software installed via:
+#' * Environment modules (e.g., lmod, environment modules)
+#' * Custom compilation from source
+#' * Alternative package managers (e.g., conda, spack, nix, homebrew)
+#' * User-space installations
+#' * Software loaded via environment variables
+#'
+#' If your system has software installed in non-standard locations, you may need to:
+#' * Install the required system packages via your system package manager
+#' * Disable system requirements checking with `PKG_SYSREQS=FALSE`
+#' * Use `options(pkg.sysreqs = FALSE)` to disable system requirements globally
+#'
+#' Use [sysreqs_status()] to check your current configuration.
+#'
+#' @name sysreqs_detection_limitations
+#' @family system requirements functions
+#' @keywords internal
+#' @examplesIf Sys.getenv("IN_PKGDOWN") == "true"
+#' # Check current system requirements status
+#' sysreqs_status()
+#'
+#' # Disable system requirements globally
+#' options(pkg.sysreqs = FALSE)
+
+check_sysreqs_enabled


### PR DESCRIPTION
Addressing #809 by enhancing transparency of sysreqs checks through:

- Showing a brief note when enabled to indicate detection depends solely on the OS package manager
- Hiding sysreqs output completely when disabled (sysreqs = FALSE)
- Suggesting to disable in likely custom environments (e.g., conda, modules)
- Updating configuration help text to clarify limitations
