### PR TITLE
Propagate async_http_ options to subprocess

### DIFF
--- a/R/subprocess.R
+++ b/R/subprocess.R
@@ -74,7 +74,7 @@ remote <- function(func, args = list()) {
   opts <- options()
   extraopts <- c("Ncpus", "BioC_mirror")
   pkg_options <- opts[
-    grepl("^pkg[.]", names(opts)) | names(opts) %in% extraopts
+    grepl("^pkg[.]", names(opts)) | grepl("^async_http_", names(opts)) | names(opts) %in% extraopts
   ]
   envs <- Sys.getenv()
   extraenvs <- c("R_BIOC_VERSION", "PATH")


### PR DESCRIPTION
Fixes https://github.com/r-lib/pak/issues/647

The subprocess was dropping `async_http_cafile` causing requests to fail behind a corporate firewall.

Added all the `async_http_` options since they're used by pkgcache

https://github.com/r-lib/pak/blob/main/src/library/pkgcache/R/aaa-async.R#L3067-L3084