### PR TITLE
Update docs to reflect that `lib` can be a vector of library paths

### DIFF
--- a/R/lockfile.R
+++ b/R/lockfile.R
@@ -15,6 +15,11 @@
 #' for caching systems.
 #'
 #' @param lockfile Path to the lock file.
+#' @param lib Character vector of library paths, or `NULL`. Used when
+#'   resolving package dependencies: packages already installed in any of
+#'   these paths are considered satisfied. If `NULL` (the default), an
+#'   empty temporary library is used, so all dependencies are resolved
+#'   from scratch regardless of what is currently installed.
 #' @inheritParams pkg_install
 #'
 #' @family lock files

--- a/R/package.R
+++ b/R/package.R
@@ -12,12 +12,16 @@
 #'   - `.`: package in the current working directory.
 #'
 #'   See "[Package sources]" for more details.
-#' @param lib Package library to install the packages to. Note that _all_
-#'   dependent packages will be installed here, even if they are
-#'   already installed in another library. The only exceptions are base
-#'   and recommended packages installed in `.Library`. These are not
-#'   duplicated in `lib`, unless a newer version of a recommended package
-#'   is needed.
+#' @param lib Character vector of library paths to consider when creating the
+#'   installation plan.
+#'   - The first library path is the target where packages will be installed.
+#'   - Additional library paths, if provided, are visible to the solver as
+#'     candidates for satisfying dependency requirements. If a needed package is
+#'     found here at an acceptable version, it won't be re-installed in
+#'     `lib[1]`.
+#'   - Base and recommended packages in `.Library` are always considered, i.e.
+#'     a recommended package is only duplicated in `lib[1]` if a newer version
+#'     is required.
 #' @param upgrade When `FALSE`, the default, pak does the minimum amount
 #'   of work to give you the latest version(s) of `pkg`. It will only upgrade
 #'   dependent packages if `pkg`, or one of their dependencies explicitly


### PR DESCRIPTION
I did not commit the `.Rd` changes from `document()` because this was a massive diff that I figure you want to do yourself. Most of that diff is from new roxygen2 and other changes, not this PR.

I'm updating the `lib` documentation that cascades into many functions.

I also put in a hypothetical different documentation for `lib` in `lockfile_create()` because the different default of `NULL` seems significant. At the very least, by touching this, it highlights that as something to consider.

Feel free to take this PR in the direction you wish.