### PR TITLE
Corrects `length(pkg)` checks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,8 +52,9 @@
   environment variable or the `pkg_http_retry` option to `FALSE` to disable
   retries.
 
-* `pkg_status()`, `pkg_deps()`, `pkg_deps_tree()`, `pkg_deps_explain()`,  now 
-  check length of `pkg` input correctly (#333, @jmbarbone)
+* Length checks for `pkg` are improved for `pkg_status()`, `pkg_deps()`, 
+  `pkg_deps_tree()`, `pkg_deps_explain()`, and `pkg_install()` (#333, #716, 
+  https://github.com/r-lib//pkgdepends/issues/449, @jmbarbone)
 
 # pak 0.10.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -52,8 +52,8 @@
   environment variable or the `pkg_http_retry` option to `FALSE` to disable
   retries.
 
-* `pkg_status()`, `pkg_deps_explaion()`, `pkg_deps_tree()` now check length of
-  `pkg` input correctly (#333, @jmbarbone)
+* `pkg_status()`, `pkg_deps()`, `pkg_deps_tree()`, `pkg_deps_explain()`,  now 
+  check length of `pkg` input correctly (#333, @jmbarbone)
 
 # pak 0.10.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,9 @@
   environment variable or the `pkg_http_retry` option to `FALSE` to disable
   retries.
 
+* `pkg_status()`, `pkg_deps_explaion()`, `pkg_deps_tree()` now check length of
+  `pkg` input correctly (#333, @jmbarbone)
+
 # pak 0.10.0
 
 * pak now supports Posit Package Manager's Sigle Sign-On authentication.

--- a/R/deps-explain.R
+++ b/R/deps-explain.R
@@ -27,7 +27,7 @@
 #' ```
 
 pkg_deps_explain <- function(pkg, deps, upgrade = TRUE, dependencies = NA) {
-  stopifnot(length(pkg == 1) && is.character(pkg))
+  stopifnot(length(pkg) == 1L, is.character(pkg))
   remote(
     function(...) {
       get("pkg_deps_explain_internal", asNamespace("pak"))(...)

--- a/R/package.R
+++ b/R/package.R
@@ -173,7 +173,7 @@ pkg_install_do_plan <- function(proposal) {
 #' ```
 
 pkg_status <- function(pkg, lib = NULL) {
-  stopifnot(length(pkg == 1) && is.character(pkg))
+  stopifnot(length(pkg) > 0L, is.character(pkg))
 
   lib <- lib %||% lib_default()
   load_extra("pillar")
@@ -237,7 +237,7 @@ pkg_remove_internal <- function(pkg, lib = NULL) {
 #' ```
 
 pkg_deps <- function(pkg, upgrade = TRUE, dependencies = NA) {
-  stopifnot(is.character(pkg))
+  stopifnot(length(pkg) > 0L, is.character(pkg))
   load_extra("pillar")
   remote(
     function(...) {
@@ -290,7 +290,7 @@ pkg_deps_internal2 <- function(pkg, upgrade, dependencies) {
 #' ```
 
 pkg_deps_tree <- function(pkg, upgrade = TRUE, dependencies = NA) {
-  stopifnot(length(pkg == 1) && is.character(pkg))
+  stopifnot(length(pkg) > 0L, is.character(pkg))
   ret <- remote(
     function(...) {
       get("pkg_deps_tree_internal", asNamespace("pak"))(...)

--- a/R/package.R
+++ b/R/package.R
@@ -78,6 +78,7 @@ pkg_install <- function(
   ask = interactive(),
   dependencies = NA
 ) {
+  stopifnot(length(pkg) > 0L)
   start <- Sys.time()
 
   lib <- lib %||% lib_default()


### PR DESCRIPTION
closes #333

- corrects  `pkg_status()` check for length `==1`
- corrects `pkg_deps()`, `pkg_deps_tree()`, `pkg_deps_explain()` check for length `>0`
- adds check for `pkg_install()` -- potentially for #716, r-lib/pkgdepends/issues/449
