### PR TITLE
Fix length() equality precedence in input validation

### DIFF
--- a/R/deps-explain.R
+++ b/R/deps-explain.R
@@ -27,7 +27,7 @@
 #' ```
 
 pkg_deps_explain <- function(pkg, deps, upgrade = TRUE, dependencies = NA) {
-  stopifnot(length(pkg == 1) && is.character(pkg))
+  stopifnot(length(pkg) == 1 && is.character(pkg))
   remote(
     function(...) {
       get("pkg_deps_explain_internal", asNamespace("pak"))(...)

--- a/R/package.R
+++ b/R/package.R
@@ -173,7 +173,7 @@ pkg_install_do_plan <- function(proposal) {
 #' ```
 
 pkg_status <- function(pkg, lib = NULL) {
-  stopifnot(length(pkg == 1) && is.character(pkg))
+  stopifnot(length(pkg) == 1 && is.character(pkg))
 
   lib <- lib %||% lib_default()
   load_extra("pillar")
@@ -290,7 +290,7 @@ pkg_deps_internal2 <- function(pkg, upgrade, dependencies) {
 #' ```
 
 pkg_deps_tree <- function(pkg, upgrade = TRUE, dependencies = NA) {
-  stopifnot(length(pkg == 1) && is.character(pkg))
+  stopifnot(length(pkg) == 1 && is.character(pkg))
   ret <- remote(
     function(...) {
       get("pkg_deps_tree_internal", asNamespace("pak"))(...)


### PR DESCRIPTION
In pkg_deps_explain(), pkg_status(), and pkg_deps_tree() the input validation guard was written as length(pkg == 1) instead of length(pkg) == 1. Because the equality test sat inside length(), the expression evaluated to length(<logical>) and never actually checked that pkg is length 1. Move the closing paren so the comparison is outside length().

Found with [ry](https://github.com/sims1253/ry)