### PR TITLE
Fix pkg length checks, cached summary flag, and sitrep github-ref

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 * `pkg_status()`, `pkg_deps_tree()` and `pkg_deps_explain()` now correctly
   error if `pkg` is not a length-1 character vector.
 
+* The install confirmation summary is now used when all download sizes are
+  known.
+
 # pak 0.11.1
 
 * Installing a package from a GitHub release (e.g. `user/repo@*release`) or

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 * The install confirmation summary is now used when all download sizes are
   known.
 
+* The `github-ref` entry is no longer missing from the sitrep data.
+
 # pak 0.11.1
 
 * Installing a package from a GitHub release (e.g. `user/repo@*release`) or

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pak (development version)
 
+* `pkg_status()`, `pkg_deps_tree()` and `pkg_deps_explain()` now correctly
+  error if `pkg` is not a length-1 character vector.
+
 # pak 0.11.1
 
 * Installing a package from a GitHub release (e.g. `user/repo@*release`) or

--- a/R/confirmation.R
+++ b/R/confirmation.R
@@ -39,7 +39,7 @@ print_install_details <- function(prop, lib, loaded) {
   b_dl <- format_bytes$pretty_bytes(sum(sol$filesize[w_dl], na.rm = TRUE))
   b_ch <- format_bytes$pretty_bytes(sum(sol$filesize[w_ch], na.rm = TRUE))
 
-  any_unk <- length(u_dl) > 0
+  any_unk <- u_dl > 0
 
   if (n_dl == 0) {
     if (n_ch > 0) {

--- a/R/deps-explain.R
+++ b/R/deps-explain.R
@@ -27,7 +27,7 @@
 #' ```
 
 pkg_deps_explain <- function(pkg, deps, upgrade = TRUE, dependencies = NA) {
-  stopifnot(length(pkg == 1) && is.character(pkg))
+  stopifnot(length(pkg) == 1 && is.character(pkg))
   remote(
     function(...) {
       get("pkg_deps_explain_internal", asNamespace("pak"))(...)

--- a/R/package.R
+++ b/R/package.R
@@ -173,7 +173,7 @@ pkg_install_do_plan <- function(proposal) {
 #' ```
 
 pkg_status <- function(pkg, lib = NULL) {
-  stopifnot(length(pkg == 1) && is.character(pkg))
+  stopifnot(length(pkg) == 1 && is.character(pkg))
 
   lib <- lib %||% lib_default()
   load_extra("pillar")
@@ -290,7 +290,7 @@ pkg_deps_internal2 <- function(pkg, upgrade, dependencies) {
 #' ```
 
 pkg_deps_tree <- function(pkg, upgrade = TRUE, dependencies = NA) {
-  stopifnot(length(pkg == 1) && is.character(pkg))
+  stopifnot(length(pkg) == 1 && is.character(pkg))
   ret <- remote(
     function(...) {
       get("pkg_deps_tree_internal", asNamespace("pak"))(...)

--- a/R/pak-sitrep-data.R
+++ b/R/pak-sitrep-data.R
@@ -38,7 +38,7 @@ pak_sitrep_data <- local({
     target_platform_arg = target_platform,
     "github-repository" = Sys.getenv("GITHUB_REPOSITORY", "-"),
     "github-sha" = Sys.getenv("GITHUB_SHA", "-"),
-    "github-ref" <- Sys.getenv("GITHUB_REF", "-"),
+    "github-ref" = Sys.getenv("GITHUB_REF", "-"),
     bundledata = bundledata
   )
 })


### PR DESCRIPTION
### Scalar `pkg` check

`pkg_status()` and `pkg_deps_tree()` in R/package.R and `pkg_deps_explain()` in R/deps-explain.R guarded `pkg` with:

```r
stopifnot(length(pkg == 1) && is.character(pkg))
```

`pkg == 1` compares elementwise, so `length(pkg == 1)` is 1 for every non-empty input. The guard rejected only the empty vector, and calls like `pkg_status(c("rlang", "cli"))` passed it. 

### Dead cached summary branch

`print_install_details()` in R/confirmation.R computed:

```r
u_dl <- sum(is.na(sol$filesize[w_dl]))
any_unk <- length(u_dl) > 0
```

`u_dl` is a `sum()`, so it always has length 1. `length(u_dl) > 0` was therefore always TRUE, and the `!any_unk` branch that prints download and cached counts in a single line never ran. 

### Missing `github-ref` sitrep entry

`pak_sitrep_data()` in R/pak-sitrep-data.R built its list with:

```r
"github-ref" <- Sys.getenv("GITHUB_REF", "-"),
```

`<-` inside `list()` does not name the element, so the sitrep data carried `github-repository` and `github-sha` but no `github-ref`. 

Found during my most recent [ry](https://github.com/sims1253/ry) audit.
